### PR TITLE
[feat] 내부인 회원가입

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/schools/repository/SchoolRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/repository/SchoolRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SchoolRepository extends JpaRepository<School, Long> {
     boolean existsBySchoolCode(String schoolCode);
@@ -30,5 +31,7 @@ public interface SchoolRepository extends JpaRepository<School, Long> {
             @Param("radiusInMeters") double radiusInMeters,
             @Param("tag") String tag
     );
+
+    Optional<School> findBySchoolCode(String schoolCode);
 
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/controller/UserController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.efub.gogildong.user.controller;
 
+import com.efub.gogildong.user.dto.request.CreateExternalUserRequestDto;
 import com.efub.gogildong.user.dto.request.CreateInternalUserRequestDto;
 import com.efub.gogildong.user.dto.response.CreateInternalUserResponseDto;
+import com.efub.gogildong.user.dto.response.CreateUserResponseDto;
 import com.efub.gogildong.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,13 @@ public class UserController {
         CreateInternalUserResponseDto responseDto = userService.createInternalUser(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
 
+    }
+
+    // 외부인 생성: POST /users/signup/external
+    @PostMapping("/signup/external")
+    public ResponseEntity<CreateUserResponseDto> createExternalUser(@RequestBody @Valid CreateExternalUserRequestDto requestDto) {
+        CreateUserResponseDto responseDto = userService.createExternalUser(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/controller/UserController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.efub.gogildong.user.controller;
+
+import com.efub.gogildong.user.dto.request.CreateInternalUserRequestDto;
+import com.efub.gogildong.user.dto.response.CreateInternalUserResponseDto;
+import com.efub.gogildong.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+
+    // 내부인 생성: POST /users/signup/internal
+    @PostMapping("/signup/internal")
+    public ResponseEntity<CreateInternalUserResponseDto> createInternalUser(@RequestBody @Valid CreateInternalUserRequestDto requestDto) {
+        CreateInternalUserResponseDto responseDto = userService.createInternalUser(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+
+    }
+
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/domain/User.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/domain/User.java
@@ -1,0 +1,89 @@
+package com.efub.gogildong.user.domain;
+
+import com.efub.gogildong.schools.domain.School;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Email
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    @Pattern(regexp = "^[0-9\\-]{9,15}$", message = "전화번호 형식이 올바르지 않습니다.")
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "school_id")
+    private School school;
+
+    @Column(nullable = false)
+    private int point = 0;
+
+    @Column(nullable = false)
+    private int total_score = 0;
+
+    @Builder
+    public User(String loginId, String password, String username, String email, String phone, UserRole role) {
+        this.loginId = loginId;
+        this.password = password;
+        this.username = username;
+        this.email = email;
+        this.phone = phone;
+        this.role = role;
+    }
+
+    public void changeSchool(School school) {
+        this.school = school;
+    }
+
+//    @Builder
+//    public Account(String email, String password, String nickname) {
+//        this.email = email;
+//        this.password = password;
+//        this.nickname = nickname;
+//    }
+//
+//    public void updateBio(String bio) {
+//        this.bio = bio;
+//    }
+//
+//    public void changeStatus(AccountStatus status) {
+//        this.status = status;
+//    }
+//
+//    public void updateNickname(String nickname) {
+//        this.nickname = nickname;
+//    }
+//
+//    public void setAccountId(Long accountId) {
+//        this.accountId = accountId;
+//    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/domain/UserRole.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/domain/UserRole.java
@@ -1,0 +1,5 @@
+package com.efub.gogildong.user.domain;
+
+public enum UserRole {
+    INTERNAL, EXTERNAL, ADMIN, SUPER_ADMIN
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/common/BaseUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/common/BaseUserRequestDto.java
@@ -1,4 +1,4 @@
-package com.efub.gogildong.user.dto.request.common;
+package com.efub.gogildong.user.dto.common;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class CreateUserRequestDto {
+public abstract class BaseUserRequestDto {
 
     @NotBlank
     private String loginId;

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateAdminUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateAdminUserRequestDto.java
@@ -1,13 +1,11 @@
 package com.efub.gogildong.user.dto.request;
 
-import com.efub.gogildong.user.domain.User;
-import com.efub.gogildong.user.dto.request.common.CreateUserRequestDto;
-import jakarta.validation.constraints.NotBlank;
+import com.efub.gogildong.user.dto.common.BaseUserRequestDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class CreateAdminUserRequestDto extends CreateUserRequestDto {
+public class CreateAdminUserRequestDto extends BaseUserRequestDto {
 
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateAdminUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateAdminUserRequestDto.java
@@ -1,0 +1,13 @@
+package com.efub.gogildong.user.dto.request;
+
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.dto.request.common.CreateUserRequestDto;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateAdminUserRequestDto extends CreateUserRequestDto {
+
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateExternalUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateExternalUserRequestDto.java
@@ -1,10 +1,28 @@
 package com.efub.gogildong.user.dto.request;
 
-import com.efub.gogildong.user.dto.request.common.CreateUserRequestDto;
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.domain.UserRole;
+import com.efub.gogildong.user.dto.common.BaseUserRequestDto;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class CreateExternalUserRequestDto extends CreateUserRequestDto {
+public class CreateExternalUserRequestDto extends BaseUserRequestDto {
+
+    @JsonIgnore
+    private final UserRole role = UserRole.EXTERNAL;
+
+    public User toEntity() {
+        return User.builder()
+                .loginId(getLoginId())
+                .password(getPassword())
+                .username(getUsername())
+                .email(getEmail())
+                .phone(getPhone())
+                .role(getRole())
+                .build();
+    }
+
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateExternalUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateExternalUserRequestDto.java
@@ -1,0 +1,10 @@
+package com.efub.gogildong.user.dto.request;
+
+import com.efub.gogildong.user.dto.request.common.CreateUserRequestDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateExternalUserRequestDto extends CreateUserRequestDto {
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateInternalUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateInternalUserRequestDto.java
@@ -2,7 +2,7 @@ package com.efub.gogildong.user.dto.request;
 
 import com.efub.gogildong.user.domain.User;
 import com.efub.gogildong.user.domain.UserRole;
-import com.efub.gogildong.user.dto.request.common.CreateUserRequestDto;
+import com.efub.gogildong.user.dto.common.BaseUserRequestDto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class CreateInternalUserRequestDto extends CreateUserRequestDto {
+public class CreateInternalUserRequestDto extends BaseUserRequestDto {
 
     @NotBlank
     private String schoolCode;

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateInternalUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateInternalUserRequestDto.java
@@ -1,0 +1,31 @@
+package com.efub.gogildong.user.dto.request;
+
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.domain.UserRole;
+import com.efub.gogildong.user.dto.request.common.CreateUserRequestDto;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateInternalUserRequestDto extends CreateUserRequestDto {
+
+    @NotBlank
+    private String schoolCode;
+
+    @JsonIgnore
+    private final UserRole role = UserRole.INTERNAL;
+
+    public User toEntity() {
+        return User.builder()
+                .loginId(getLoginId())
+                .password(getPassword())
+                .username(getUsername())
+                .email(getEmail())
+                .phone(getPhone())
+                .role(getRole())
+                .build();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateSuperAdminUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateSuperAdminUserRequestDto.java
@@ -1,10 +1,10 @@
 package com.efub.gogildong.user.dto.request;
 
-import com.efub.gogildong.user.dto.request.common.CreateUserRequestDto;
+import com.efub.gogildong.user.dto.common.BaseUserRequestDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class CreateSuperAdminUserRequestDto extends CreateUserRequestDto {
+public class CreateSuperAdminUserRequestDto extends BaseUserRequestDto {
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateSuperAdminUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateSuperAdminUserRequestDto.java
@@ -1,0 +1,10 @@
+package com.efub.gogildong.user.dto.request;
+
+import com.efub.gogildong.user.dto.request.common.CreateUserRequestDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateSuperAdminUserRequestDto extends CreateUserRequestDto {
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/UpdateInternalCodeRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/UpdateInternalCodeRequestDto.java
@@ -1,0 +1,4 @@
+package com.efub.gogildong.user.dto.request;
+
+public class UpdateInternalCodeRequestDto {
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/UpdateUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/UpdateUserRequestDto.java
@@ -1,0 +1,4 @@
+package com.efub.gogildong.user.dto.request;
+
+public class UpdateUserRequestDto {
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/common/CreateUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/common/CreateUserRequestDto.java
@@ -1,0 +1,25 @@
+package com.efub.gogildong.user.dto.request.common;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateUserRequestDto {
+
+    @NotBlank
+    private String loginId;
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String phone;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/response/CreateInternalUserResponseDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/response/CreateInternalUserResponseDto.java
@@ -1,0 +1,42 @@
+package com.efub.gogildong.user.dto.response;
+
+import com.efub.gogildong.schools.domain.School;
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.domain.UserRole;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateInternalUserResponseDto {
+
+    private Long userId;
+    private UserRole role;
+    private String schoolCode;
+    private String schoolName;
+
+//    public static CreateUserResponseDto from(User user) {
+//        return CreateUserResponseDto.builder()
+//                .userId(user.getUserId())
+//                .role(user.getRole())
+//                .build();
+//    }
+
+    // User + School을 함께 받는 팩토리 (권장)
+    public static CreateInternalUserResponseDto of(User user, School school) {
+        return CreateInternalUserResponseDto.builder()
+                .userId(user.getUserId())
+                .role(user.getRole())
+                .schoolCode(school != null ? school.getSchoolCode() : null)
+                .schoolName(school != null ? school.getSchoolName() : null)
+                .build();
+    }
+
+    // 기존 시그니처도 유지하고 싶다면 (트랜잭션 내에서만 안전)
+    public static CreateInternalUserResponseDto from(User user) {
+        School s = user.getSchool(); // LAZY 주의
+        return of(user, s);
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/response/CreateInternalUserResponseDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/response/CreateInternalUserResponseDto.java
@@ -3,13 +3,13 @@ package com.efub.gogildong.user.dto.response;
 import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.user.domain.User;
 import com.efub.gogildong.user.domain.UserRole;
-import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
-@Builder
 @Getter
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
 public class CreateInternalUserResponseDto {
 
     private Long userId;
@@ -17,14 +17,6 @@ public class CreateInternalUserResponseDto {
     private String schoolCode;
     private String schoolName;
 
-//    public static CreateUserResponseDto from(User user) {
-//        return CreateUserResponseDto.builder()
-//                .userId(user.getUserId())
-//                .role(user.getRole())
-//                .build();
-//    }
-
-    // User + School을 함께 받는 팩토리 (권장)
     public static CreateInternalUserResponseDto of(User user, School school) {
         return CreateInternalUserResponseDto.builder()
                 .userId(user.getUserId())
@@ -34,9 +26,8 @@ public class CreateInternalUserResponseDto {
                 .build();
     }
 
-    // 기존 시그니처도 유지하고 싶다면 (트랜잭션 내에서만 안전)
     public static CreateInternalUserResponseDto from(User user) {
-        School s = user.getSchool(); // LAZY 주의
+        School s = user.getSchool();
         return of(user, s);
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/response/CreateUserResponseDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/response/CreateUserResponseDto.java
@@ -1,0 +1,21 @@
+package com.efub.gogildong.user.dto.response;
+
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.domain.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateUserResponseDto {
+
+    private final Long userId;
+    private final UserRole role;
+
+    public static CreateUserResponseDto from(User user) {
+        return CreateUserResponseDto.builder()
+                .userId(user.getUserId())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/response/UpdateUserResponseDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/response/UpdateUserResponseDto.java
@@ -1,0 +1,22 @@
+package com.efub.gogildong.user.dto.response;
+
+import com.efub.gogildong.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UpdateUserResponseDto {
+
+    private String username;
+    private String email;
+    private String phone;
+
+    public static UpdateUserResponseDto from(User user) {
+        return UpdateUserResponseDto.builder()
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .phone(user.getPhone())
+                .build();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/repository/UserRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.efub.gogildong.user.repository;
+
+import com.efub.gogildong.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    // userId로 조회
+    Optional<User> findByUserId(Long userId);
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
@@ -1,0 +1,67 @@
+package com.efub.gogildong.user.service;
+
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
+import com.efub.gogildong.schools.domain.School;
+import com.efub.gogildong.schools.repository.SchoolRepository;
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.dto.request.CreateInternalUserRequestDto;
+import com.efub.gogildong.user.dto.response.CreateInternalUserResponseDto;
+import com.efub.gogildong.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final SchoolRepository schoolRepository;
+
+    // 내부인 생성
+    @Transactional
+    public CreateInternalUserResponseDto createInternalUser(CreateInternalUserRequestDto request) {
+
+        // 이메일 형식 체크
+        EmailValidator.validateOrThrow(request.getEmail());
+
+        // schoolCode로 학교 조회
+        School school = schoolRepository.findBySchoolCode(request.getSchoolCode())
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.SCHOOL_NOT_FOUND));
+
+        // 내부인 생성
+        User user = request.toEntity();
+        user.changeSchool(school);
+
+        User saved = userRepository.save(user);
+        return CreateInternalUserResponseDto.from(saved);
+    }
+
+    public final class EmailValidator {
+        private static final Pattern EMAIL_PATTERN =
+                Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+
+        private EmailValidator() {}
+
+        public static void validateOrThrow(String email) {
+            if (email == null || !EMAIL_PATTERN.matcher(email).matches()) {
+                throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다: " + email);
+            }
+        }
+    }
+
+    // 내부인 소속 학교 변경
+
+    // 외부인 생성
+
+    // 학교 관리자 생성
+
+    // 전체 관리자 생성
+
+    // user 정보 수정
+
+    // user 삭제
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
@@ -5,8 +5,10 @@ import com.efub.gogildong.global.exception.GoGildongException;
 import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.schools.repository.SchoolRepository;
 import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.dto.request.CreateExternalUserRequestDto;
 import com.efub.gogildong.user.dto.request.CreateInternalUserRequestDto;
 import com.efub.gogildong.user.dto.response.CreateInternalUserResponseDto;
+import com.efub.gogildong.user.dto.response.CreateUserResponseDto;
 import com.efub.gogildong.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -40,6 +42,31 @@ public class UserService {
         return CreateInternalUserResponseDto.from(saved);
     }
 
+    // 내부인 소속 학교 변경
+
+    // 외부인 생성
+    @Transactional
+    public CreateUserResponseDto createExternalUser(CreateExternalUserRequestDto request) {
+
+        // 이메일 형식 체크
+        EmailValidator.validateOrThrow(request.getEmail());
+
+        // 외부인 생성
+        User user = request.toEntity();
+
+        User saved = userRepository.save(user);
+        return CreateUserResponseDto.from(saved);
+    }
+
+    // 학교 관리자 생성
+
+    // 전체 관리자 생성
+
+    // user 정보 수정
+
+    // user 삭제
+
+    // 이메일 검증
     public final class EmailValidator {
         private static final Pattern EMAIL_PATTERN =
                 Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
@@ -52,16 +79,4 @@ public class UserService {
             }
         }
     }
-
-    // 내부인 소속 학교 변경
-
-    // 외부인 생성
-
-    // 학교 관리자 생성
-
-    // 전체 관리자 생성
-
-    // user 정보 수정
-
-    // user 삭제
 }


### PR DESCRIPTION
## 연관 이슈

#3 

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->
- user mvc 틀을 만들고 내부인 회원가입 api를 만들었습니다.

<br/>

## 📌 구현 기능

- [x] 내부인 회원가입
  <img width="1926" height="1102" alt="image" src="https://github.com/user-attachments/assets/91eeaa72-44ce-47d6-8297-2a221cd8cb82" />
- [x] 외부인 회원가입
  <img width="1912" height="1008" alt="image" src="https://github.com/user-attachments/assets/bb8aefe4-69c5-4549-991a-fa4736724142" />



<br/>

## ⚠️ 어려웠던 점과 해결 과정
막혔던 부분과 어떻게 해결했는지 작성해주세요. (아래 부분은 지우고 작성)
- 어려웠던 점 : 회원 역할이 여러 개라서 단일 테이블에서 어떻게 구분,확장할지 고민됐습니다. 또한 역할별 요청/응답 DTO에 겹치는 필드가 많아 중복 관리가 어려웠습니다.
- 해결 과정 : 
  - 사용자 공통 정보는 단일 user 테이블에 필수 컬럼으로 유지하고, 역할별로 필요한 추가 속성은 확장 테이블 또는 별도 조회로 가져오도록 설계했습니다.
  - DTO는 공통 DTO를 분리하고, 역할별 DTO가 이를 상속,합성해 필요한 필드만 추가하도록 정리하여 중복을 줄였습니다.

<br/>
  
## ⚠️ 참고 사항 및 주의할 점
- reportId 컬럼은 report 테이블 생성 후 외래키 매핑을 추가할 예정입니다.

<br/>
