### PR TITLE
fix(#17): 학교 관리자 인증 코드 추가

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/schools/domain/School.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/domain/School.java
@@ -5,9 +5,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
+import org.springframework.security.crypto.bcrypt.BCrypt;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Entity
 @Getter
@@ -37,12 +39,36 @@ public class School {
     @OneToMany(mappedBy = "school")
     List<SchoolTag> SchoolTags = new ArrayList<>();
 
+    @Column(nullable = false, unique = true, length = 10)
+    String adminCode;
+
+    private static final ThreadLocalRandom RND = ThreadLocalRandom.current();
+
+    private static String randomDigits(int len) {
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) sb.append(RND.nextInt(10));
+        return sb.toString();
+    }
+
+    // 코드 매칭
+    public boolean matchesAdminCode(String raw) {
+        return raw != null && adminCode != null && adminCode.equals(raw);
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (adminCode == null || adminCode.isBlank()) {
+            adminCode = randomDigits(10);
+        }
+    }
+
     @Builder
-    public School(String schoolCode, String schoolName, String address, Point location, EduLevel eduLevel) {
+    public School(String schoolCode, String schoolName, String address, Point location, EduLevel eduLevel, String adminCode) {
         this.schoolCode = schoolCode;
         this.schoolName = schoolName;
         this.address = address;
         this.location = location;
         this.eduLevel = eduLevel;
+        this.adminCode = adminCode;
     }
 }


### PR DESCRIPTION
## 연관 이슈

close #17

<br/>

## 개요

학교 엔티티에 학교 관리자 인증 코드(adminCode) 자동 발급 로직을 추가했습니다.

<br/>

## 📌 구현 기능

- [x] 학교 관리자 인증 코드 자동 발급 추가
  <img width="886" height="239" alt="image" src="https://github.com/user-attachments/assets/0d750a0a-0f8f-4355-b6ec-8e76b75cb83f" />

<br/>

## ⚠️ 어려웠던 점과 해결 과정
- NOT NULL 에러(admin_code가 null로 저장됨). @PrePersist 미적용/UPDATE 경로로 저장 → @PrePersist로 비어 있으면 6~8자리 숫자 자동 생성, 새 엔티티로 INSERT 보장

<br/>
  
