### PR TITLE
feat(#33): jwt 기반 로그인 구현 및 회원가입 api 수정

### DIFF
--- a/gogildong/build.gradle
+++ b/gogildong/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	implementation 'com.opencsv:opencsv:5.12.0' // csv reader
 	implementation 'org.apache.poi:poi-ooxml:5.4.1'
     implementation "org.springframework.security:spring-security-crypto"
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/gogildong/src/main/java/com/efub/gogildong/auth/controller/AdminController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/auth/controller/AdminController.java
@@ -1,0 +1,16 @@
+package com.efub.gogildong.auth.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@ResponseBody
+public class AdminController {
+
+    @GetMapping("/admin")
+    public String adminP() {
+
+        return "admin Controller";
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/auth/controller/MainController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/auth/controller/MainController.java
@@ -1,0 +1,31 @@
+package com.efub.gogildong.auth.controller;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+@Controller
+@ResponseBody
+public class MainController {
+
+    @GetMapping("/")
+    public String mainP() {
+
+        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iter = authorities.iterator();
+        GrantedAuthority auth = iter.next();
+        String role = auth.getAuthority();
+
+        return "Main Controller : "+loginId+ role;
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/auth/dto/CustomUserDetails.java
+++ b/gogildong/src/main/java/com/efub/gogildong/auth/dto/CustomUserDetails.java
@@ -1,0 +1,34 @@
+package com.efub.gogildong.auth.dto;
+
+import com.efub.gogildong.user.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) { this.user = user; }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of((GrantedAuthority) () -> "ROLE_" + user.getRole().name());
+    }
+
+    @Override
+    public String getPassword() { return user.getPassword(); }
+
+    @Override
+    public String getUsername() { return user.getLoginId(); }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}
+
+

--- a/gogildong/src/main/java/com/efub/gogildong/auth/jwt/JwtFilter.java
+++ b/gogildong/src/main/java/com/efub/gogildong/auth/jwt/JwtFilter.java
@@ -1,0 +1,70 @@
+package com.efub.gogildong.auth.jwt;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authorization.substring(7);
+
+        // 만료/형식/서명은 여기서 걸러냄(만료 시 401로 내보내고 싶다면 EntryPoint에서 처리)
+        try {
+            if (jwtUtil.isExpired(token)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+        } catch (JwtException e) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // refresh 토큰이 헤더로 오면 거부
+        String typ = jwtUtil.getType(token);
+        if ("refresh".equalsIgnoreCase(typ)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 토큰에서 subject/role 추출 (role은 도메인 롤)
+        String username = jwtUtil.getSubject(token);
+        String domainRole = jwtUtil.getRole(token);
+        String authority = "ROLE_" + domainRole;
+
+        // DB hit 없이 경량 UserDetails 생성
+        var userDetails = org.springframework.security.core.userdetails.User
+                .withUsername(username)
+                .password("")
+                .authorities(authority)
+                .build();
+
+        var authToken = new UsernamePasswordAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/auth/jwt/JwtUtil.java
+++ b/gogildong/src/main/java/com/efub/gogildong/auth/jwt/JwtUtil.java
@@ -1,0 +1,59 @@
+package com.efub.gogildong.auth.jwt;
+
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtUtil {
+
+    private final Key key;
+    private final JwtParser parser;
+    private final long accessTtlMillis;
+    private final long refreshTtlMillis;
+
+    public JwtUtil(
+            @Value("${spring.jwt.secret}") String secretBase64,
+            @Value("${spring.jwt.access-ttl:900000}") long accessTtlMillis,
+            @Value("${spring.jwt.refresh-ttl:604800000}") long refreshTtlMillis
+    ) {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretBase64));
+        this.parser = Jwts.parserBuilder().setSigningKey(this.key).build();
+        this.accessTtlMillis = accessTtlMillis;
+        this.refreshTtlMillis = refreshTtlMillis;
+    }
+
+    // 발급: 토큰에는 'subject=username'과 'role=도메인롤'만
+    public String createAccessToken(String username, String domainRole) {
+        return buildToken(username, Map.of("role", domainRole, "typ", "access"), accessTtlMillis);
+    }
+
+    public String createRefreshToken(String username) {
+        return buildToken(username, Map.of("typ", "refresh"), refreshTtlMillis);
+    }
+
+    private String buildToken(String subject, Map<String, Object> claims, long ttlMillis) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ttlMillis))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 조회/검증
+    public Claims parseClaims(String token) { return parser.parseClaimsJws(token).getBody(); }
+    public String getSubject(String token) { return parseClaims(token).getSubject(); }
+    public String getRole(String token)    { return parseClaims(token).get("role", String.class); }
+    public boolean isExpired(String token) { return parseClaims(token).getExpiration().before(new Date()); }
+    public String getType(String token)    { return parseClaims(token).get("typ", String.class); }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/auth/jwt/LoginFilter.java
+++ b/gogildong/src/main/java/com/efub/gogildong/auth/jwt/LoginFilter.java
@@ -1,0 +1,89 @@
+package com.efub.gogildong.auth.jwt;
+
+import com.efub.gogildong.auth.dto.CustomUserDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.core.Authentication;
+
+import java.io.IOException;
+
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    public LoginFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil) {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+        setFilterProcessesUrl("/auth/login"); // 로그인 URL
+        setAuthenticationManager(authenticationManager);
+
+        setUsernameParameter("loginId");
+        setPasswordParameter("password");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+        String loginId, password;
+        try {
+            if (request.getContentType() != null && request.getContentType().contains("application/json")) {
+                var node = new ObjectMapper().readTree(request.getInputStream());
+                loginId = node.get("loginId").asText();
+                password = node.get("password").asText();
+            } else {
+                loginId = obtainUsername(request);
+                password = obtainPassword(request);
+            }
+        } catch (IOException e) {
+            throw new AuthenticationServiceException("Invalid login payload", e);
+        }
+
+        return authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(loginId, password)
+        );
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                            FilterChain chain, Authentication authentication) throws IOException {
+        CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+        String username = principal.getUsername(); // 내부적으로 loginId 반환하도록 구현되어 있어야 함
+
+        String domainRole = principal.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)            // ex) ROLE_ADMIN
+                .map(a -> a.startsWith("ROLE_") ? a.substring(5) : a) // -> ADMIN
+                .findFirst().orElse("EXTERNAL");
+
+        String accessToken  = jwtUtil.createAccessToken(username, domainRole);
+        String refreshToken = jwtUtil.createRefreshToken(username);
+
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.setHeader("X-Refresh-Token", refreshToken);
+        response.setHeader("Access-Control-Expose-Headers", "Authorization,X-Refresh-Token");
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("""
+            {"accessToken":"%s","refreshToken":"%s"}
+        """.formatted(accessToken, refreshToken));
+        response.getWriter().flush();
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                              AuthenticationException failed) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"error\":\"invalid_credentials\"}");
+        response.getWriter().flush();
+    }
+}
+
+

--- a/gogildong/src/main/java/com/efub/gogildong/auth/service/CustomUserDetailsService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.efub.gogildong.auth.service;
+
+import com.efub.gogildong.auth.dto.CustomUserDetails;
+import com.efub.gogildong.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        var user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UsernameNotFoundException("loginId not found: " + loginId));
+        return new CustomUserDetails(user);
+    }
+
+
+}

--- a/gogildong/src/main/java/com/efub/gogildong/global/config/SecurityConfig.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/config/SecurityConfig.java
@@ -1,0 +1,88 @@
+package com.efub.gogildong.global.config;
+
+import com.efub.gogildong.auth.jwt.JwtFilter;
+import com.efub.gogildong.auth.jwt.JwtUtil;
+import com.efub.gogildong.auth.jwt.LoginFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public LoginFilter loginFilter(AuthenticationManager authenticationManager) {
+        LoginFilter filter = new LoginFilter(authenticationManager, jwtUtil);
+        filter.setFilterProcessesUrl("/auth/login");
+        filter.setUsernameParameter("loginId");
+        filter.setPasswordParameter("password");
+        return filter;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authenticationProvider(authenticationProvider())
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> {}) // 전역 CORS 설정이 있다면 빈만 두면 활성화
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((req, res, e) -> res.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+                        .accessDeniedHandler((req, res, e) -> res.sendError(HttpServletResponse.SC_FORBIDDEN))
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/login",
+                                "/auth/refresh",
+                                "/users/signup/internal",
+                                "/users/signup/external",
+                                "/users/signup/admin",
+                                "/users/signup/super-admin"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+
+                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+
+                .addFilterAt(loginFilter(authenticationManager()), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/domain/User.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/domain/User.java
@@ -4,22 +4,20 @@ import com.efub.gogildong.schools.domain.School;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "users")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String loginId;
 
     @Column(nullable = false)
@@ -64,26 +62,4 @@ public class User {
         this.school = school;
     }
 
-//    @Builder
-//    public Account(String email, String password, String nickname) {
-//        this.email = email;
-//        this.password = password;
-//        this.nickname = nickname;
-//    }
-//
-//    public void updateBio(String bio) {
-//        this.bio = bio;
-//    }
-//
-//    public void changeStatus(AccountStatus status) {
-//        this.status = status;
-//    }
-//
-//    public void updateNickname(String nickname) {
-//        this.nickname = nickname;
-//    }
-//
-//    public void setAccountId(Long accountId) {
-//        this.accountId = accountId;
-//    }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateAdminUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateAdminUserRequestDto.java
@@ -24,7 +24,6 @@ public class CreateAdminUserRequestDto extends BaseUserRequestDto {
     public User toEntity() {
         return User.builder()
                 .loginId(getLoginId())
-                .password(getPassword())
                 .username(getUsername())
                 .email(getEmail())
                 .phone(getPhone())

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateExternalUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateExternalUserRequestDto.java
@@ -17,7 +17,6 @@ public class CreateExternalUserRequestDto extends BaseUserRequestDto {
     public User toEntity() {
         return User.builder()
                 .loginId(getLoginId())
-                .password(getPassword())
                 .username(getUsername())
                 .email(getEmail())
                 .phone(getPhone())

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateInternalUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/CreateInternalUserRequestDto.java
@@ -21,7 +21,6 @@ public class CreateInternalUserRequestDto extends BaseUserRequestDto {
     public User toEntity() {
         return User.builder()
                 .loginId(getLoginId())
-                .password(getPassword())
                 .username(getUsername())
                 .email(getEmail())
                 .phone(getPhone())

--- a/gogildong/src/main/java/com/efub/gogildong/user/repository/UserRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/repository/UserRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    // userId로 조회
     Optional<User> findByUserId(Long userId);
+    Optional<User> findByLoginId(String loginId);
+
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.efub.gogildong.user.dto.response.CreateInternalUserResponseDto;
 import com.efub.gogildong.user.dto.response.CreateUserResponseDto;
 import com.efub.gogildong.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final SchoolRepository schoolRepository;
+    private final PasswordEncoder passwordEncoder;
 
     // 내부인 생성
     @Transactional
@@ -35,12 +37,16 @@ public class UserService {
         School school = schoolRepository.findBySchoolCode(request.getSchoolCode())
                 .orElseThrow(() -> new GoGildongException(ExceptionCode.SCHOOL_NOT_FOUND));
 
-        // 내부인 생성
+        // 엔티티 생성
         User user = request.toEntity();
+
+        // 비밀번호 인코딩
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+
+        // 학교 매핑
         user.changeSchool(school);
 
-        User saved = userRepository.save(user);
-        return CreateInternalUserResponseDto.from(saved);
+        return CreateInternalUserResponseDto.from(userRepository.save(user));
     }
 
     // 내부인 소속 학교 변경
@@ -49,38 +55,32 @@ public class UserService {
     @Transactional
     public CreateUserResponseDto createExternalUser(CreateExternalUserRequestDto request) {
 
-        // 이메일 형식 체크
         EmailValidator.validateOrThrow(request.getEmail());
 
-        // 외부인 생성
         User user = request.toEntity();
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
 
-        User saved = userRepository.save(user);
-        return CreateUserResponseDto.from(saved);
+        return CreateUserResponseDto.from(userRepository.save(user));
     }
 
     // 학교 관리자 생성
-    @Transactional
     public CreateInternalUserResponseDto createAdminUser(CreateAdminUserRequestDto request) {
 
-        // 이메일 형식 체크
         EmailValidator.validateOrThrow(request.getEmail());
 
-        // schoolCode로 학교 조회
         School school = schoolRepository.findBySchoolCode(request.getSchoolCode())
                 .orElseThrow(() -> new GoGildongException(ExceptionCode.SCHOOL_NOT_FOUND));
 
-        // adminCode로 학교 관리자 검증
+        // adminCode 검증
         if (!school.matchesAdminCode(request.getAdminCode())) {
             throw new GoGildongException(ExceptionCode.SCHOOL_NOT_FOUND);
         }
 
-        // 외부인 생성
         User user = request.toEntity();
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.changeSchool(school);
 
-        User saved = userRepository.save(user);
-        return CreateInternalUserResponseDto.from(saved);
+        return CreateInternalUserResponseDto.from(userRepository.save(user));
     }
 
     // 전체 관리자 생성

--- a/gogildong/src/main/resources/application.yml
+++ b/gogildong/src/main/resources/application.yml
@@ -10,3 +10,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+  jwt:
+    secret: ${JWT_SECRET}
+    access-ttl: 900000
+    refresh-ttl: 604800000


### PR DESCRIPTION
## 연관 이슈

close #33 

<br/>

## 개요

<!-- 이 PR을 간략하게 설명해주세요. -->

<br/>

## 📌 구현 기능

- [x] jwt 기반 로그인 구현
  <img width="1896" height="1036" alt="image" src="https://github.com/user-attachments/assets/06ff7f1a-cdf3-42d3-bcff-0eaf66280d74" />


<br/>

## ⚠️ 어려웠던 점과 해결 과정
- JWT 토큰 검증 시 401 발생 → 필터 순서 문제였음
- Encoded password does not look like BCrypt 경고 & 401 → DB에 평문/다른 해시 저장 → 회원가입 시 passwordEncoder.encode(raw)로 저장, 로그인은 그대로 BCryptPasswordEncoder.matches에 맡김
- 로그인 식별자 불일치(username vs loginId) → 요청 JSON 키와 조회 칼럼 불일치 → LoginFilter에서 loginId/password를 읽고, UserRepository.findByLoginId(...)로 조회하도록 통일

<br/>
  
## ⚠️ 참고 사항 및 주의할 점
맥/리눅스 : `openssl rand -base64 32` 
윈도우(powershell): `[Convert]::ToBase64String((New-Object byte[] 64 | % {$_=Get-Random -Minimum 0 -Maximum 256}))`
으로 jwt 비밀 키를 생성하고 ${JWT_SECRET} 환경변수 설정해주시면 됩니다.


<br/>

