### PR TITLE
feat(#35): 회원 수정 api

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/auth/dto/CustomUserDetails.java
+++ b/gogildong/src/main/java/com/efub/gogildong/auth/dto/CustomUserDetails.java
@@ -16,8 +16,12 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of((GrantedAuthority) () -> "ROLE_" + user.getRole().name());
+        var authorities = new ArrayList<GrantedAuthority>();
+        authorities.add(() -> "ROLE_" + user.getRole().name()); // ROLE_INTERNAL 등
+        return authorities;
     }
+
+    public Long getUserId() { return user.getUserId(); }
 
     @Override
     public String getPassword() { return user.getPassword(); }

--- a/gogildong/src/main/java/com/efub/gogildong/auth/jwt/JwtFilter.java
+++ b/gogildong/src/main/java/com/efub/gogildong/auth/jwt/JwtFilter.java
@@ -5,12 +5,16 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
@@ -19,52 +23,92 @@ public class JwtFilter extends OncePerRequestFilter {
         this.jwtUtil = jwtUtil;
     }
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
 
-        String authorization = request.getHeader("Authorization");
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
-            filterChain.doFilter(request, response);
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+
+        final String path = request.getServletPath();
+
+        // 인증 제외 경로 & CORS preflight 는 바로 패스
+        if (path.startsWith("/auth/") || "OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            log.debug("[JWT] Skip path or preflight: {} {}", request.getMethod(), path);
+            chain.doFilter(request, response);
             return;
         }
 
-        String token = authorization.substring(7);
+        // 이미 인증된 경우 패스
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            log.debug("[JWT] SecurityContext already set. path={}", path);
+            chain.doFilter(request, response);
+            return;
+        }
 
-        // 만료/형식/서명은 여기서 걸러냄(만료 시 401로 내보내고 싶다면 EntryPoint에서 처리)
+        // 헤더 추출
+        String header = request.getHeader("Authorization");
+        if (!StringUtils.hasText(header) || !header.startsWith("Bearer ")) {
+            log.debug("[JWT] No Bearer token. path={}", path);
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.substring(7);
+        log.debug("[JWT] Bearer token detected. prefix={}", token.length() > 10 ? token.substring(0, 10) + "..." : token);
+
+        // 토큰 유형/유효성 체크
         try {
-            if (jwtUtil.isExpired(token)) {
-                filterChain.doFilter(request, response);
+            // refresh 토큰이면 거부 (access 만 허용)
+            String typ = jwtUtil.getType(token);
+            if ("refresh".equalsIgnoreCase(typ)) {
+                log.warn("[JWT] Refresh token used for API. path={}", path);
+                chain.doFilter(request, response);
                 return;
             }
+
+            if (jwtUtil.isExpired(token)) {
+                log.warn("[JWT] Token expired. path={}", path);
+                chain.doFilter(request, response);
+                return;
+            }
+
+            // 서명·형식 등 추가 검증이 있다면 여기서 수행 (예: jwtUtil.validateToken(token))
         } catch (JwtException e) {
-            filterChain.doFilter(request, response);
+            log.warn("[JWT] Token invalid: {} (path={})", e.getMessage(), path);
+            chain.doFilter(request, response);
+            return;
+        } catch (Exception e) {
+            log.error("[JWT] Validation error: {} (path={})", e.getMessage(), path);
+            chain.doFilter(request, response);
             return;
         }
 
-        // refresh 토큰이 헤더로 오면 거부
-        String typ = jwtUtil.getType(token);
-        if ("refresh".equalsIgnoreCase(typ)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        // 토큰에서 subject/role 추출 (role은 도메인 롤)
+        // 클레임에서 subject/role 추출
         String username = jwtUtil.getSubject(token);
         String domainRole = jwtUtil.getRole(token);
-        String authority = "ROLE_" + domainRole;
+        if (!StringUtils.hasText(username) || !StringUtils.hasText(domainRole)) {
+            log.warn("[JWT] Missing subject/role in token. path={}", path);
+            chain.doFilter(request, response);
+            return;
+        }
 
-        // DB hit 없이 경량 UserDetails 생성
+        String authority = "ROLE_" + domainRole.trim().toUpperCase();
         var userDetails = org.springframework.security.core.userdetails.User
                 .withUsername(username)
-                .password("")
+                .password("") // 자격증명은 불필요
                 .authorities(authority)
                 .build();
 
-        var authToken = new UsernamePasswordAuthenticationToken(
+        // SecurityContext 설정
+        var authentication = new UsernamePasswordAuthenticationToken(
                 userDetails, null, userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(authToken);
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        filterChain.doFilter(request, response);
+        log.debug("[JWT] SecurityContext set. user={}, authorities={}, path={}",
+                username, userDetails.getAuthorities(), path);
+
+        chain.doFilter(request, response);
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/auth/jwt/LoginFilter.java
+++ b/gogildong/src/main/java/com/efub/gogildong/auth/jwt/LoginFilter.java
@@ -33,15 +33,27 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
             throws AuthenticationException {
+
         String loginId, password;
         try {
-            if (request.getContentType() != null && request.getContentType().contains("application/json")) {
+            String ct = request.getContentType();
+            if (ct != null && ct.toLowerCase().startsWith("application/json")) {
                 var node = new ObjectMapper().readTree(request.getInputStream());
-                loginId = node.get("loginId").asText();
-                password = node.get("password").asText();
+
+                var idNode = node.get("loginId");
+                var pwNode = node.get("password");
+                if (idNode == null || pwNode == null) {
+                    throw new AuthenticationServiceException("Missing loginId or password in JSON body");
+                }
+
+                loginId  = idNode.asText();
+                password = pwNode.asText();
             } else {
-                loginId = obtainUsername(request);
+                loginId  = obtainUsername(request); // setUsernameParameter("loginId") 적용됨
                 password = obtainPassword(request);
+                if (loginId == null || password == null) {
+                    throw new AuthenticationServiceException("Missing loginId or password in form parameters");
+                }
             }
         } catch (IOException e) {
             throw new AuthenticationServiceException("Invalid login payload", e);

--- a/gogildong/src/main/java/com/efub/gogildong/global/config/CorsMvcConfig.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/config/CorsMvcConfig.java
@@ -1,0 +1,16 @@
+package com.efub.gogildong.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+
+        corsRegistry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000");
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/global/config/SecurityConfig.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/config/SecurityConfig.java
@@ -7,10 +7,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -22,6 +24,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -39,6 +42,7 @@ public class SecurityConfig {
         provider.setPasswordEncoder(passwordEncoder());
         return provider;
     }
+
 
     @Bean
     public AuthenticationManager authenticationManager() throws Exception {
@@ -68,21 +72,17 @@ public class SecurityConfig {
                         .accessDeniedHandler((req, res, e) -> res.sendError(HttpServletResponse.SC_FORBIDDEN))
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/auth/login",
-                                "/auth/refresh",
-                                "/users/signup/internal",
-                                "/users/signup/external",
-                                "/users/signup/admin",
-                                "/users/signup/super-admin"
-                        ).permitAll()
-                        .anyRequest().authenticated()
-                )
+                .requestMatchers("/error").permitAll()
+                .requestMatchers("/auth/login", "/auth/refresh", "/users/signup/**").permitAll()
+                .requestMatchers(HttpMethod.PATCH, "/users/**").authenticated()
+                .anyRequest().authenticated()
+        )
 
                 .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
-
                 .addFilterAt(loginFilter(authenticationManager()), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
+
+
 }

--- a/gogildong/src/main/java/com/efub/gogildong/global/exception/ClientExceptionCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/exception/ClientExceptionCode.java
@@ -24,4 +24,8 @@ public enum ClientExceptionCode {
 
     // 허가
     UNAUTHORIZED_SCHOOL_ACCESS,
+
+    // 사용자
+    USER_NOT_FOUND,
+    ACCESS_DENIED,
 }

--- a/gogildong/src/main/java/com/efub/gogildong/global/exception/ExceptionCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/exception/ExceptionCode.java
@@ -27,7 +27,11 @@ public enum ExceptionCode {
     DOOR_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST, ClientExceptionCode.DOOR_TYPE_BAD_REQUEST, "유효하지 않은 문 타입입니다."),
 
     // 허가
-    UNAUTHORIZED_SCHOOL_ACCESS(HttpStatus.UNAUTHORIZED, ClientExceptionCode.UNAUTHORIZED_SCHOOL_ACCESS, "허가되지 않은 사용자가 학교 정보에 접근했습니다.");
+    UNAUTHORIZED_SCHOOL_ACCESS(HttpStatus.UNAUTHORIZED, ClientExceptionCode.UNAUTHORIZED_SCHOOL_ACCESS, "허가되지 않은 사용자가 학교 정보에 접근했습니다."),
+
+    // 사용자
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."),
+    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, ClientExceptionCode.ACCESS_DENIED, "접근이 허용되지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final ClientExceptionCode clientExceptionCode;

--- a/gogildong/src/main/java/com/efub/gogildong/user/controller/UserController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/controller/UserController.java
@@ -1,24 +1,19 @@
 package com.efub.gogildong.user.controller;
 
-import com.efub.gogildong.user.dto.request.CreateAdminUserRequestDto;
-import com.efub.gogildong.user.dto.request.CreateExternalUserRequestDto;
-import com.efub.gogildong.user.dto.request.CreateInternalUserRequestDto;
-import com.efub.gogildong.user.dto.request.UpdateInternalSchoolRequestDto;
+import com.efub.gogildong.user.dto.request.*;
 import com.efub.gogildong.user.dto.response.InternalUserResponseDto;
 import com.efub.gogildong.user.dto.response.CreateUserResponseDto;
+import com.efub.gogildong.user.dto.response.UpdateUserResponseDto;
 import com.efub.gogildong.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.Authentication;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
@@ -36,13 +31,11 @@ public class UserController {
     // 내부인 학교 변경: PATCH /users/me/school
     @PreAuthorize("hasAnyRole('INTERNAL')")
     @PatchMapping("/me/school")
-    public ResponseEntity<InternalUserResponseDto> updateInternalSchool(
-            org.springframework.security.core.Authentication authentication,
-            @RequestBody @jakarta.validation.Valid UpdateInternalSchoolRequestDto request) {
+    public ResponseEntity<InternalUserResponseDto> updateInternalSchool(Authentication authentication,
+                                                                        @RequestBody @Valid UpdateInternalSchoolRequestDto request) {
 
-        String loginId = authentication.getName(); // JwtFilter에서 set한 username (loginId)
-        InternalUserResponseDto dto =
-                userService.updateInternalUserSchoolByLoginId(loginId, request.getSchoolCode());
+        String loginId = authentication.getName();
+        InternalUserResponseDto dto = userService.updateInternalUserSchoolByLoginId(loginId, request.getSchoolCode());
         return ResponseEntity.ok(dto);
     }
 
@@ -59,6 +52,20 @@ public class UserController {
         InternalUserResponseDto responseDto = userService.createAdminUser(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
+
+    // user 정보 수정: PATCH /users/me
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping("/me")
+    public ResponseEntity<UpdateUserResponseDto> updateUser(
+            Authentication authentication,
+            @RequestBody @Valid UpdateUserRequestDto request) {
+
+        String loginId = authentication.getName(); // JwtFilter에서 set한 username
+        UpdateUserResponseDto responseDto = userService.updateUserByLoginId(loginId, request);
+        return ResponseEntity.ok(responseDto);
+    }
+
+
 
 
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/controller/UserController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/controller/UserController.java
@@ -3,14 +3,17 @@ package com.efub.gogildong.user.controller;
 import com.efub.gogildong.user.dto.request.CreateAdminUserRequestDto;
 import com.efub.gogildong.user.dto.request.CreateExternalUserRequestDto;
 import com.efub.gogildong.user.dto.request.CreateInternalUserRequestDto;
-import com.efub.gogildong.user.dto.response.CreateInternalUserResponseDto;
+import com.efub.gogildong.user.dto.request.UpdateInternalSchoolRequestDto;
+import com.efub.gogildong.user.dto.response.InternalUserResponseDto;
 import com.efub.gogildong.user.dto.response.CreateUserResponseDto;
 import com.efub.gogildong.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,10 +27,23 @@ public class UserController {
 
     // 내부인 생성: POST /users/signup/internal
     @PostMapping("/signup/internal")
-    public ResponseEntity<CreateInternalUserResponseDto> createInternalUser(@RequestBody @Valid CreateInternalUserRequestDto requestDto) {
-        CreateInternalUserResponseDto responseDto = userService.createInternalUser(requestDto);
+    public ResponseEntity<InternalUserResponseDto> createInternalUser(@RequestBody @Valid CreateInternalUserRequestDto requestDto) {
+        InternalUserResponseDto responseDto = userService.createInternalUser(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
 
+    }
+
+    // 내부인 학교 변경: PATCH /users/me/school
+    @PreAuthorize("hasAnyRole('INTERNAL')")
+    @PatchMapping("/me/school")
+    public ResponseEntity<InternalUserResponseDto> updateInternalSchool(
+            org.springframework.security.core.Authentication authentication,
+            @RequestBody @jakarta.validation.Valid UpdateInternalSchoolRequestDto request) {
+
+        String loginId = authentication.getName(); // JwtFilter에서 set한 username (loginId)
+        InternalUserResponseDto dto =
+                userService.updateInternalUserSchoolByLoginId(loginId, request.getSchoolCode());
+        return ResponseEntity.ok(dto);
     }
 
     // 외부인 생성: POST /users/signup/external
@@ -39,8 +55,10 @@ public class UserController {
 
     // 학교 관리자 생성: POST /users/signup/admin
     @PostMapping("/signup/admin")
-    public ResponseEntity<CreateInternalUserResponseDto> createAdminUser(@RequestBody @Valid CreateAdminUserRequestDto requestDto) {
-        CreateInternalUserResponseDto responseDto = userService.createAdminUser(requestDto);
+    public ResponseEntity<InternalUserResponseDto> createAdminUser(@RequestBody @Valid CreateAdminUserRequestDto requestDto) {
+        InternalUserResponseDto responseDto = userService.createAdminUser(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
+
+
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/domain/User.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/domain/User.java
@@ -62,4 +62,10 @@ public class User {
         this.school = school;
     }
 
+    public void updateUser(String username, String email, String phone) {
+        this.username = username;
+        this.email = email;
+        this.phone = phone;
+    }
+
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/domain/UserRole.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/domain/UserRole.java
@@ -1,5 +1,8 @@
 package com.efub.gogildong.user.domain;
 
 public enum UserRole {
-    INTERNAL, EXTERNAL, ADMIN, SUPER_ADMIN
+    INTERNAL, EXTERNAL, ADMIN, SUPER_ADMIN;
+    public boolean isInternal() {
+        return this == INTERNAL;
+    }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/UpdateInternalCodeRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/UpdateInternalCodeRequestDto.java
@@ -1,4 +1,0 @@
-package com.efub.gogildong.user.dto.request;
-
-public class UpdateInternalCodeRequestDto {
-}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/UpdateInternalSchoolRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/UpdateInternalSchoolRequestDto.java
@@ -1,0 +1,16 @@
+package com.efub.gogildong.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateInternalSchoolRequestDto {
+
+    @NotBlank
+    private String schoolCode;
+
+}

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/request/UpdateUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/request/UpdateUserRequestDto.java
@@ -1,4 +1,13 @@
 package com.efub.gogildong.user.dto.request;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class UpdateUserRequestDto {
+
+    private String username;
+    private String email;
+    private String phone;
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/response/InternalUserResponseDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/response/InternalUserResponseDto.java
@@ -6,19 +6,18 @@ import com.efub.gogildong.user.domain.UserRole;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.experimental.SuperBuilder;
 
 @Getter
 @Builder
-public class CreateInternalUserResponseDto {
+public class InternalUserResponseDto {
 
     private Long userId;
     private UserRole role;
     private String schoolCode;
     private String schoolName;
 
-    public static CreateInternalUserResponseDto of(User user, School school) {
-        return CreateInternalUserResponseDto.builder()
+    public static InternalUserResponseDto of(User user, School school) {
+        return InternalUserResponseDto.builder()
                 .userId(user.getUserId())
                 .role(user.getRole())
                 .schoolCode(school != null ? school.getSchoolCode() : null)
@@ -26,7 +25,7 @@ public class CreateInternalUserResponseDto {
                 .build();
     }
 
-    public static CreateInternalUserResponseDto from(User user) {
+    public static InternalUserResponseDto from(User user) {
         School s = user.getSchool();
         return of(user, s);
     }

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/response/UpdateUserResponseDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/response/UpdateUserResponseDto.java
@@ -4,19 +4,21 @@ import com.efub.gogildong.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 
-@Builder
 @Getter
+@Builder
 public class UpdateUserResponseDto {
-
+    private Long userId;
     private String username;
     private String email;
     private String phone;
 
     public static UpdateUserResponseDto from(User user) {
         return UpdateUserResponseDto.builder()
+                .userId(user.getUserId())
                 .username(user.getUsername())
                 .email(user.getEmail())
                 .phone(user.getPhone())
                 .build();
     }
 }
+

--- a/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
@@ -8,8 +8,10 @@ import com.efub.gogildong.user.domain.User;
 import com.efub.gogildong.user.dto.request.CreateAdminUserRequestDto;
 import com.efub.gogildong.user.dto.request.CreateExternalUserRequestDto;
 import com.efub.gogildong.user.dto.request.CreateInternalUserRequestDto;
+import com.efub.gogildong.user.dto.request.UpdateUserRequestDto;
 import com.efub.gogildong.user.dto.response.InternalUserResponseDto;
 import com.efub.gogildong.user.dto.response.CreateUserResponseDto;
+import com.efub.gogildong.user.dto.response.UpdateUserResponseDto;
 import com.efub.gogildong.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -102,6 +104,15 @@ public class UserService {
     // 전체 관리자 생성
 
     // user 정보 수정
+    @Transactional
+    public UpdateUserResponseDto updateUserByLoginId(String loginId, UpdateUserRequestDto requestDto) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+
+        user.updateUser(requestDto.getUsername(), requestDto.getEmail(), requestDto.getPhone());
+        return UpdateUserResponseDto.from(user);
+    }
+
 
     // user 삭제
 

--- a/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
@@ -8,7 +8,7 @@ import com.efub.gogildong.user.domain.User;
 import com.efub.gogildong.user.dto.request.CreateAdminUserRequestDto;
 import com.efub.gogildong.user.dto.request.CreateExternalUserRequestDto;
 import com.efub.gogildong.user.dto.request.CreateInternalUserRequestDto;
-import com.efub.gogildong.user.dto.response.CreateInternalUserResponseDto;
+import com.efub.gogildong.user.dto.response.InternalUserResponseDto;
 import com.efub.gogildong.user.dto.response.CreateUserResponseDto;
 import com.efub.gogildong.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +28,7 @@ public class UserService {
 
     // 내부인 생성
     @Transactional
-    public CreateInternalUserResponseDto createInternalUser(CreateInternalUserRequestDto request) {
+    public InternalUserResponseDto createInternalUser(CreateInternalUserRequestDto request) {
 
         // 이메일 형식 체크
         EmailValidator.validateOrThrow(request.getEmail());
@@ -46,10 +46,26 @@ public class UserService {
         // 학교 매핑
         user.changeSchool(school);
 
-        return CreateInternalUserResponseDto.from(userRepository.save(user));
+        return InternalUserResponseDto.from(userRepository.save(user));
     }
 
-    // 내부인 소속 학교 변경
+    // 내부인 학교 변경
+    @Transactional
+    public InternalUserResponseDto updateInternalUserSchoolByLoginId(String loginId, String schoolCode) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+
+        if (!user.getRole().isInternal()) {
+            throw new GoGildongException(ExceptionCode.ACCESS_DENIED);
+        }
+
+        School school = schoolRepository.findBySchoolCode(schoolCode)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.SCHOOL_NOT_FOUND));
+
+        user.changeSchool(school); // 변경감지로 업데이트
+        return InternalUserResponseDto.from(user);
+    }
+
 
     // 외부인 생성
     @Transactional
@@ -64,7 +80,7 @@ public class UserService {
     }
 
     // 학교 관리자 생성
-    public CreateInternalUserResponseDto createAdminUser(CreateAdminUserRequestDto request) {
+    public InternalUserResponseDto createAdminUser(CreateAdminUserRequestDto request) {
 
         EmailValidator.validateOrThrow(request.getEmail());
 
@@ -80,7 +96,7 @@ public class UserService {
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.changeSchool(school);
 
-        return CreateInternalUserResponseDto.from(userRepository.save(user));
+        return InternalUserResponseDto.from(userRepository.save(user));
     }
 
     // 전체 관리자 생성


### PR DESCRIPTION
## 연관 이슈

close #35 

<br/>

## 개요

- 내부인이 학교 코드를 수정하여 학교를 변경합니다.
- 내부인, 외부인, 학교 관리자, 전체 관리자가 사용이름, 이메일, 전화번호를 수정합니다.

<br/>

## 📌 구현 기능

- [x] 내부인 학교 코드 수정 api
  <img width="1908" height="808" alt="image" src="https://github.com/user-attachments/assets/9d71af0c-c09d-4136-895c-fdd7af41cc78" />

- [x] 이름, 이메일, 전화번호 수정 api
  <img width="1916" height="944" alt="image" src="https://github.com/user-attachments/assets/792b7625-17ce-4b86-9107-6faa1db38347" />


<br/>

## ⚠️ 어려웠던 점과 해결 과정
authentication.getName()을 userId로 착각하여 Long id로 조회 시도하여 타입/조회 오류가 발생했었다..



<br/>
  
## ⚠️ 참고 사항 및 주의할 점
- `/auth/login` 으로 accessToken 받으면 postman 테스트할 때 header에
Authorization: Bearer \<accessToken\> 


