### PR TITLE
[feat] 학교 정보 조회에 대한 유저 유효성 검사 추가

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/schools/controller/SchoolFloorController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/controller/SchoolFloorController.java
@@ -7,6 +7,7 @@ import com.efub.gogildong.schools.dto.response.FloorPlanImageResponse;
 import com.efub.gogildong.schools.service.SchoolFloorService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,19 +29,21 @@ public class SchoolFloorController {
     * 타입 별 층에 존재하는 시설 조회
     * */
     @GetMapping("/{schoolId}/floors/{floorId}")
-    public ResponseEntity<FacilityListResponse> getFacilityListByFloorId(@PathVariable Long schoolId,
+    public ResponseEntity<FacilityListResponse> getFacilityListByFloorId(Authentication authentication,
+                                                                         @PathVariable Long schoolId,
                                                                          @PathVariable Long floorId,
                                                                          @RequestParam(name = "type", defaultValue = "all") TagCategory type) {
-        return ResponseEntity.ok(schoolFloorService.getAllFacilitiesByFloorId(schoolId, floorId, type));
+        return ResponseEntity.ok(schoolFloorService.getAllFacilitiesByFloorId(authentication.getName(), schoolId, floorId, type));
     }
 
     /*
     * 층 별 도면 조회
     */
     @GetMapping("/{schoolId}/floors/{floorId}/plan")
-    public ResponseEntity<FloorPlanImageResponse> getFloorPlanImageByFloorId(@PathVariable Long schoolId,
+    public ResponseEntity<FloorPlanImageResponse> getFloorPlanImageByFloorId(Authentication authentication,
+                                                                             @PathVariable Long schoolId,
                                                                              @PathVariable Long floorId){
-        return ResponseEntity.ok(schoolFloorService.getFloorPlanImageByFloorId(schoolId, floorId));
+        return ResponseEntity.ok(schoolFloorService.getFloorPlanImageByFloorId(authentication.getName(), schoolId, floorId));
     }
 
 }

--- a/gogildong/src/main/java/com/efub/gogildong/schools/repository/SchoolViewRequestRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/repository/SchoolViewRequestRepository.java
@@ -1,9 +1,14 @@
 package com.efub.gogildong.schools.repository;
 
+import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.schools.domain.SchoolViewRequest;
+import com.efub.gogildong.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface SchoolViewRequestRepository extends JpaRepository<SchoolViewRequest, Long> {
+    Optional<SchoolViewRequest> findBySchoolAndUser(School school, User user);
 }

--- a/gogildong/src/main/java/com/efub/gogildong/schools/service/SchoolFloorService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/service/SchoolFloorService.java
@@ -11,6 +11,8 @@ import com.efub.gogildong.global.exception.GoGildongException;
 import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.schools.domain.constants.TagCategory;
 import com.efub.gogildong.schools.dto.response.*;
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,6 +28,8 @@ public class SchoolFloorService {
     private final BuildingRepository buildingRepository;
     private final FloorRepository floorRepository;
     private final FacilityRepository facilityRepository;
+    private final UserService userService;
+    private final SchoolViewRequestService schoolViewRequestService;
 
     /*
     * 학교 id로 해당 학교에 존재하는 층을 조회합니다.
@@ -55,12 +59,13 @@ public class SchoolFloorService {
     * 층 id를 이용해 타입 별로 층에 존재하는 시설을 조회합니다.
     * */
     @Transactional(readOnly = true)
-    public FacilityListResponse getAllFacilitiesByFloorId(Long schoolId,
+    public FacilityListResponse getAllFacilitiesByFloorId(String loginId,
+                                                          Long schoolId,
                                                           Long floorId,
                                                           TagCategory tagCategory) {
+        User user = userService.getUserByLoginId(loginId);
         School school = schoolService.getSchoolById(schoolId);
-
-        // TODO: 추후 회원 유효성 검사 필요
+        schoolViewRequestService.validateViewRequestBySchoolAndUser(school, user);
 
         Floor floor = getFloorById(floorId);
 
@@ -83,10 +88,11 @@ public class SchoolFloorService {
     * 층 별 도면을 조회합니다.
     * */
     @Transactional(readOnly = true)
-    public FloorPlanImageResponse getFloorPlanImageByFloorId(Long schoolId, Long floorId) {
-        // TODO: 추후 회원 유효성 검사 진행
+    public FloorPlanImageResponse getFloorPlanImageByFloorId(String loginId, Long schoolId, Long floorId) {
+        User user = userService.getUserByLoginId(loginId);
         Floor floor = getFloorById(floorId);
         School school = schoolService.getSchoolById(schoolId);
+        schoolViewRequestService.validateViewRequestBySchoolAndUser(school, user);
         getValidatedSchoolByFloorId(floor, school);
         return FloorPlanImageResponse.from(floor);
     }

--- a/gogildong/src/main/java/com/efub/gogildong/schools/service/SchoolViewRequestService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/service/SchoolViewRequestService.java
@@ -2,6 +2,7 @@ package com.efub.gogildong.schools.service;
 
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
+import com.efub.gogildong.schools.domain.RequestStatus;
 import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.schools.domain.SchoolViewRequest;
 import com.efub.gogildong.schools.dto.request.SchoolViewRequestRequest;
@@ -27,5 +28,16 @@ public class SchoolViewRequestService {
         SchoolViewRequest viewRequest = request.toEntity(school, user);
         schoolViewRequestRepository.save(viewRequest);
         return SchoolViewRequestResponse.from(viewRequest);
+    }
+
+    // 해당 학교, 사용자에게 열람 권한이 있는지 확인합니다.
+    public void validateViewRequestBySchoolAndUser(School school, User user) {
+        SchoolViewRequest schoolViewRequest = schoolViewRequestRepository.findBySchoolAndUser(school, user)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.UNAUTHORIZED_SCHOOL_ACCESS));
+
+        // 해당 학교 소속 아니면서, 열람 요청 받아서 승인 받지 않은 경우
+        if(!(user.getSchool().equals(school) || schoolViewRequest.getStatus().equals(RequestStatus.APPROVED))) {
+            throw new GoGildongException(ExceptionCode.UNAUTHORIZED_SCHOOL_ACCESS);
+        }
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/schools/service/SchoolViewRequestService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/service/SchoolViewRequestService.java
@@ -32,11 +32,15 @@ public class SchoolViewRequestService {
 
     // 해당 학교, 사용자에게 열람 권한이 있는지 확인합니다.
     public void validateViewRequestBySchoolAndUser(School school, User user) {
-        SchoolViewRequest schoolViewRequest = schoolViewRequestRepository.findBySchoolAndUser(school, user)
-                .orElseThrow(() -> new GoGildongException(ExceptionCode.UNAUTHORIZED_SCHOOL_ACCESS));
+        SchoolViewRequest schoolViewRequest =
+                schoolViewRequestRepository.findBySchoolAndUser(school, user)
+                        .orElse(null);
 
-        // 해당 학교 소속 아니면서, 열람 요청 받아서 승인 받지 않은 경우
-        if(!(user.getSchool().equals(school) || schoolViewRequest.getStatus().equals(RequestStatus.APPROVED))) {
+        boolean isSameSchool = user.getSchool().equals(school);
+        boolean isApproved = (schoolViewRequest != null && schoolViewRequest.getStatus() == RequestStatus.APPROVED);
+
+        // 해당 학교 소속이 아니면서, 열람 승인도 받지 않은 경우
+        if (!isSameSchool && !isApproved) {
             throw new GoGildongException(ExceptionCode.UNAUTHORIZED_SCHOOL_ACCESS);
         }
     }

--- a/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
@@ -54,8 +54,7 @@ public class UserService {
     // 내부인 학교 변경
     @Transactional
     public InternalUserResponseDto updateInternalUserSchoolByLoginId(String loginId, String schoolCode) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+        User user = getUserByLoginId(loginId);
 
         if (!user.getRole().isInternal()) {
             throw new GoGildongException(ExceptionCode.ACCESS_DENIED);
@@ -106,8 +105,7 @@ public class UserService {
     // user 정보 수정
     @Transactional
     public UpdateUserResponseDto updateUserByLoginId(String loginId, UpdateUserRequestDto requestDto) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+        User user = getUserByLoginId(loginId);
 
         user.updateUser(requestDto.getUsername(), requestDto.getEmail(), requestDto.getPhone());
         return UpdateUserResponseDto.from(user);
@@ -128,5 +126,11 @@ public class UserService {
                 throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다: " + email);
             }
         }
+    }
+
+    // login id로 유저 반환
+    public User getUserByLoginId(String loginId) {
+        return userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 연관 이슈

#19 

## 개요
학교 정보 조회에 대한 유저 유효성 검사 추가

<br/>

## 📌 구현 기능

- [X] 위치별 도면 조회에 유저 유효성 검사 추가
- [X] 층 별 시설 리스트 조회에 유저 유효성 검사 추가

## ⚠️ 참고 사항 및 주의할 점
```
// 해당 학교, 사용자에게 열람 권한이 있는지 확인합니다.
    public void validateViewRequestBySchoolAndUser(School school, User user) {
        SchoolViewRequest schoolViewRequest =
                schoolViewRequestRepository.findBySchoolAndUser(school, user)
                        .orElse(null);

        boolean isSameSchool = user.getSchool().equals(school);
        boolean isApproved = (schoolViewRequest != null && schoolViewRequest.getStatus() == RequestStatus.APPROVED);

        // 해당 학교 소속이 아니면서, 열람 승인도 받지 않은 경우
        if (!isSameSchool && !isApproved) {
            throw new GoGildongException(ExceptionCode.UNAUTHORIZED_SCHOOL_ACCESS);
        }
    }
```
- `ViewRequestService`에서 학교에 대한 조회 권한 확인 시 해당 메서드 이용해주시면 될 거 같아요! 