### PR TITLE
feat(#24): rank api 구현

### DIFF
--- a/gogildong/build.gradle
+++ b/gogildong/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'io.lettuce:lettuce-core'
 }
 
 tasks.named('test') {

--- a/gogildong/src/main/java/com/efub/gogildong/global/config/RedisConfig.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.efub.gogildong.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory cf) {
+        StringRedisTemplate t = new StringRedisTemplate(cf);
+        return t;
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/rank/controller/RankController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/controller/RankController.java
@@ -1,0 +1,74 @@
+package com.efub.gogildong.rank.controller;
+
+import com.efub.gogildong.rank.dto.response.*;
+import com.efub.gogildong.rank.service.RankService;
+import com.efub.gogildong.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/rank")
+@RequiredArgsConstructor
+public class RankController {
+
+    private final RankService rankService;
+    private final UserService userService;
+
+    /* Redis Test용 API */
+    @PostMapping("/rebuild")
+    public void rebuild() {
+        rankService.rebuildAllRanksFromDB();
+    }
+
+    /* GET /rank : 전체 랭킹 조회 (상위 100) */
+    @GetMapping
+    @PreAuthorize("isAuthenticated()") // 명세: access token 필요
+    public GlobalRankListResponse getGlobal(Authentication authentication) {
+        return rankService.getGlobalTop();
+    }
+
+    /* GET /rank/mine : 전체에서 내 랭킹 조회 */
+    @GetMapping("/mine")
+    @PreAuthorize("isAuthenticated()")
+    public MyGlobalRankResponse getMyGlobal(Authentication authentication) {
+        String loginId = authentication.getName();
+        long userId = userService.getUserByLoginId(loginId).getUserId();
+        return rankService.getMyGlobalRank(userId);
+    }
+
+    /* GET /rank/school : 교내 전체 랭킹 조회 */
+    @GetMapping("/school")
+    @PreAuthorize("isAuthenticated()") // 명세: access token 필요
+    public GlobalRankListResponse getSchool(Authentication authentication) {
+        String loginId = authentication.getName();
+        long userId = userService.getUserByLoginId(loginId).getUserId();
+        return rankService.getSchoolTopByUser(userId);
+    }
+
+    /* GET /rank/school/mine : 교내에서 내 랭킹 조회 */
+    @GetMapping("/school/mine")
+    @PreAuthorize("isAuthenticated()")
+    public SchoolMyRankResponse getMySchool(Authentication authentication) {
+        String loginId = authentication.getName();
+        long userId = userService.getUserByLoginId(loginId).getUserId();
+        return rankService.getMySchoolRank(userId);
+    }
+
+    /* GET /rank/schools : 전체 학교별 랭킹 */
+    @GetMapping("/schools")
+    @PreAuthorize("isAuthenticated()")
+    public SchoolRankListResponse getSchools(Authentication authentication) {
+        return rankService.getSchoolsBoard();
+    }
+
+    /* GET /rank/schools/mine : 우리 학교의 학교랭킹 */
+    @GetMapping("/schools/mine")
+    @PreAuthorize("isAuthenticated()")
+    public MySchoolVsSchoolResponse getMySchoolVsSchool(Authentication authentication) {
+        String loginId = authentication.getName();
+        long userId = userService.getUserByLoginId(loginId).getUserId();
+        return rankService.getMySchoolVsSchoolRank(userId);
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/rank/dto/GlobalRankItemDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/dto/GlobalRankItemDto.java
@@ -1,0 +1,15 @@
+package com.efub.gogildong.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GlobalRankItemDto {
+    private int rank;
+    private Long user_id;
+    private String user_name;
+    private long total_score;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/rank/dto/SchoolRankItemDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/dto/SchoolRankItemDto.java
@@ -1,0 +1,15 @@
+package com.efub.gogildong.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SchoolRankItemDto {
+    private int rank;
+    private Long school_id;
+    private String school_name;
+    private long total_score;      // 학교 총합 점수
+}

--- a/gogildong/src/main/java/com/efub/gogildong/rank/dto/response/GlobalRankListResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/dto/response/GlobalRankListResponse.java
@@ -1,0 +1,13 @@
+package com.efub.gogildong.rank.dto.response;
+
+import com.efub.gogildong.rank.dto.GlobalRankItemDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter @Builder @AllArgsConstructor
+public class GlobalRankListResponse {
+    private List<GlobalRankItemDto> rankings;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/rank/dto/response/MyGlobalRankResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/dto/response/MyGlobalRankResponse.java
@@ -1,0 +1,14 @@
+package com.efub.gogildong.rank.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter @Builder @AllArgsConstructor
+public class MyGlobalRankResponse {
+    private Long user_id;
+    private String user_name;
+    private long score;
+    private Integer global_rank;
+    private Double global_percentile;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/rank/dto/response/MySchoolVsSchoolResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/dto/response/MySchoolVsSchoolResponse.java
@@ -1,0 +1,17 @@
+package com.efub.gogildong.rank.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MySchoolVsSchoolResponse {
+    private Long user_id;
+    private Long school_id;
+    private String school_name;
+    private long score;
+    private Integer school_rank;
+    private Double school_percentile;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/rank/dto/response/SchoolMyRankResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/dto/response/SchoolMyRankResponse.java
@@ -1,0 +1,16 @@
+package com.efub.gogildong.rank.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SchoolMyRankResponse {
+    private Long user_id;
+    private String user_name;
+    private long score;
+    private Integer my_rank;
+    private Double my_percentile;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/rank/dto/response/SchoolRankListResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/dto/response/SchoolRankListResponse.java
@@ -1,0 +1,15 @@
+package com.efub.gogildong.rank.dto.response;
+
+import com.efub.gogildong.rank.dto.SchoolRankItemDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SchoolRankListResponse {
+    private List<SchoolRankItemDto> rankings;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/rank/service/RankService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/service/RankService.java
@@ -1,0 +1,323 @@
+package com.efub.gogildong.rank.service;
+
+import com.efub.gogildong.rank.dto.GlobalRankItemDto;
+import com.efub.gogildong.rank.dto.SchoolRankItemDto;
+import com.efub.gogildong.rank.dto.response.*;
+import com.efub.gogildong.schools.domain.School;
+import com.efub.gogildong.schools.repository.SchoolRepository;
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RankService {
+
+    private static final String GLOBAL_KEY = "rank:global";
+    private static final String SCHOOL_KEY_FMT = "rank:school:%d";
+    private static final String SCHOOLS_KEY = "rank:schools";
+    private static final int TOP_LIMIT = 100; // 상위 100명 반환, 나중에 환경변수로 넣는 게 좋을듯
+
+    private final StringRedisTemplate redis;
+    private final UserRepository userRepository;
+    private final SchoolRepository schoolRepository;
+
+    // Redis Rebuild
+    @Transactional
+    public void rebuildAllRanksFromDB() {
+        // 0) 기존 키 정리
+        redis.delete(GLOBAL_KEY);
+        redis.delete(SCHOOLS_KEY);
+        var schoolKeys = redis.keys("rank:school:*");
+        if (!schoolKeys.isEmpty()) redis.delete(schoolKeys);
+
+        // 1) 전체 유저를 돌며 글로벌/교내 채우고, 학교 합계를 누적
+        var z = redis.opsForZSet();
+        Map<Long, Long> schoolSum = new HashMap<>();
+
+        userRepository.findAll().forEach(u -> {
+            long uid = u.getUserId();
+            long score = u.getTotal_score();
+            z.add(GLOBAL_KEY, memberUser(uid), score);
+
+            var school = u.getSchool();
+            if (school != null) {
+                long sid = school.getSchoolId();
+                z.add(schoolKey(sid), memberUser(uid), score);
+                schoolSum.merge(sid, score, Long::sum);
+            }
+        });
+
+        schoolSum.forEach((sid, sum) -> z.add(SCHOOLS_KEY, memberSchool(sid), sum));
+    }
+
+    // 사용자 점수 upsert
+    @Transactional
+    public void upsertUserScore(long userId, long newScore) {
+        var z = redis.opsForZSet();
+
+        Double prev = z.score(GLOBAL_KEY, memberUser(userId));
+        double oldScore = prev == null ? 0d : prev;
+
+        z.add(GLOBAL_KEY, memberUser(userId), newScore);
+
+        userRepository.findById(userId).ifPresent(u -> {
+            if (u.getSchool() != null) {
+                long sid = u.getSchool().getSchoolId();
+                z.add(schoolKey(sid), memberUser(userId), newScore);
+                double delta = newScore - oldScore;
+                if (delta != 0) {
+                    z.incrementScore(SCHOOLS_KEY, memberSchool(sid), delta);
+                }
+            }
+        });
+    }
+
+    // 사용자 학교 변경 시 호출: 이전/새 학교 키에서 이동 처리
+    @Transactional
+    public void onUserSchoolChanged(long userId, Long oldSchoolId, Long newSchoolId) {
+        var z = redis.opsForZSet();
+        Double sObj = z.score(GLOBAL_KEY, memberUser(userId));
+        double s = sObj == null ? 0d : sObj;
+
+        if (oldSchoolId != null) {
+            z.remove(schoolKey(oldSchoolId), memberUser(userId));
+            z.incrementScore(SCHOOLS_KEY, memberSchool(oldSchoolId), -s);
+        }
+        if (newSchoolId != null) {
+            z.add(schoolKey(newSchoolId), memberUser(userId), s);
+            z.incrementScore(SCHOOLS_KEY, memberSchool(newSchoolId), s);
+        }
+    }
+
+    // GET /rank : 전체 랭킹 조회
+    public GlobalRankListResponse getGlobalTop() {
+        ZSetOperations<String, String> z = redis.opsForZSet();
+        Set<ZSetOperations.TypedTuple<String>> rows =
+                z.reverseRangeWithScores(GLOBAL_KEY, 0, TOP_LIMIT - 1);
+
+        if (rows == null || rows.isEmpty()) {
+            return GlobalRankListResponse.builder().rankings(List.of()).build();
+        }
+
+        List<Long> userIds = rows.stream()
+                .map(t -> parseUserId(t.getValue()))
+                .toList();
+
+        Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getUserId, u -> u));
+
+        List<GlobalRankItemDto> items = new ArrayList<>(rows.size());
+        int i = 0;
+        for (ZSetOperations.TypedTuple<String> t : rows) {
+            long uid = parseUserId(t.getValue());
+            long score = t.getScore() == null ? 0L : t.getScore().longValue();
+            User u = userMap.get(uid);
+
+            items.add(GlobalRankItemDto.builder()
+                    .rank(++i)
+                    .user_id(uid)
+                    .user_name(u != null ? u.getUsername() : null)
+                    .total_score(score)
+                    .build());
+        }
+
+        return GlobalRankListResponse.builder().rankings(items).build();
+    }
+
+    // GET /rank/mine : 전체 내 랭킹 조회
+    public MyGlobalRankResponse getMyGlobalRank(long userId) {
+        ZSetOperations<String, String> z = redis.opsForZSet();
+
+        Long zeroBasedRank = z.reverseRank(GLOBAL_KEY, memberUser(userId));
+        Double score = z.score(GLOBAL_KEY, memberUser(userId));
+        Long total = z.zCard(GLOBAL_KEY);
+
+        User u = userRepository.findById(userId).orElse(null);
+
+        Integer rank1Based = zeroBasedRank == null ? null : (int) (zeroBasedRank + 1);
+        long myScore = score == null ? 0L : score.longValue();
+
+        Double percentile = bottomPercentile(rank1Based, total);
+
+        return MyGlobalRankResponse.builder()
+                .user_id(userId)
+                .user_name(u != null ? u.getUsername() : null)
+                .score(myScore)
+                .global_rank(rank1Based)
+                .global_percentile(percentile)
+                .build();
+    }
+
+    // GET /rank/school : 교내 전체 랭킹 조회
+    public GlobalRankListResponse getSchoolTopByUser(long userId) {
+        User me = userRepository.findById(userId).orElse(null);
+        if (me == null || me.getSchool() == null) {
+            // 소속 학교 없으면 빈 리스트 반환
+            return GlobalRankListResponse.builder().rankings(List.of()).build();
+        }
+        long schoolId = me.getSchool().getSchoolId();
+        String key = schoolKey(schoolId);
+
+        ZSetOperations<String, String> z = redis.opsForZSet();
+        Set<ZSetOperations.TypedTuple<String>> rows =
+                z.reverseRangeWithScores(key, 0, TOP_LIMIT - 1);
+
+        if (rows == null || rows.isEmpty()) {
+            return GlobalRankListResponse.builder().rankings(List.of()).build();
+        }
+
+        List<Long> userIds = rows.stream()
+                .map(t -> parseUserId(t.getValue()))
+                .toList();
+
+        Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getUserId, u -> u));
+
+        List<GlobalRankItemDto> items = new ArrayList<>(rows.size());
+        int i = 0;
+        for (ZSetOperations.TypedTuple<String> t : rows) {
+            long uid = parseUserId(t.getValue());
+            long score = t.getScore() == null ? 0L : t.getScore().longValue();
+            User u = userMap.get(uid);
+
+            items.add(GlobalRankItemDto.builder()
+                    .rank(++i)
+                    .user_id(uid)
+                    .user_name(u != null ? u.getUsername() : null)
+                    .total_score(score)
+                    .build());
+        }
+        return GlobalRankListResponse.builder().rankings(items).build();
+    }
+
+    // GET /rank/school/mine : 교내 내 랭킹 조회
+    public SchoolMyRankResponse getMySchoolRank(long userId) {
+        User me = userRepository.findById(userId).orElse(null);
+        if (me == null || me.getSchool() == null) {
+            return SchoolMyRankResponse.builder()
+                    .user_id(userId)
+                    .user_name(me != null ? me.getUsername() : null)
+                    .score(0)
+                    .my_rank(null)
+                    .my_percentile(null)
+                    .build();
+        }
+
+        long schoolId = me.getSchool().getSchoolId();
+        String key = schoolKey(schoolId);
+
+        ZSetOperations<String, String> z = redis.opsForZSet();
+        Long zeroBasedRank = z.reverseRank(key, memberUser(userId));
+        Double score = z.score(key, memberUser(userId));
+        Long total = z.zCard(key);
+
+        Integer rank1Based = zeroBasedRank == null ? null : (int) (zeroBasedRank + 1);
+        long myScore = score == null ? 0L : score.longValue();
+
+        Double percentile = bottomPercentile(rank1Based, total);
+
+        return SchoolMyRankResponse.builder()
+                .user_id(me.getUserId())
+                .user_name(me.getUsername())
+                .score(myScore)
+                .my_rank(rank1Based)
+                .my_percentile(percentile)
+                .build();
+    }
+
+    // GET /rank/schools : 전체 학교별 랭킹 조회
+    public SchoolRankListResponse getSchoolsBoard() {
+        var z = redis.opsForZSet();
+        var rows = z.reverseRangeWithScores(SCHOOLS_KEY, 0, TOP_LIMIT - 1);
+        if (rows == null || rows.isEmpty()) {
+            return SchoolRankListResponse.builder().rankings(List.of()).build();
+        }
+
+        List<Long> schoolIds = rows.stream()
+                .map(t -> Long.parseLong(Objects.requireNonNull(t.getValue()).substring(2)))
+                .toList();
+
+        Map<Long, School> byId = schoolRepository.findAllById(schoolIds).stream()
+                .collect(Collectors.toMap(School::getSchoolId, s -> s));
+
+        List<SchoolRankItemDto> items = new ArrayList<>();
+        int i = 0;
+        for (var t : rows) {
+            long sid = Long.parseLong(Objects.requireNonNull(t.getValue()).substring(2));
+            long sum = t.getScore() == null ? 0L : t.getScore().longValue();
+            School s = byId.get(sid);
+
+            items.add(SchoolRankItemDto.builder()
+                    .rank(++i)
+                    .school_id(sid)
+                    .school_name(s != null ? s.getSchoolName() : null)
+                    .total_score(sum)
+                    .build());
+        }
+        return SchoolRankListResponse.builder().rankings(items).build();
+    }
+
+    // GET /rank/schools/mine : 전체 학교 중 내 학교 랭킹 조회
+    public MySchoolVsSchoolResponse getMySchoolVsSchoolRank(long userId) {
+        var me = userRepository.findById(userId).orElse(null);
+        if (me == null || me.getSchool() == null) {
+            return MySchoolVsSchoolResponse.builder()
+                    .user_id(userId)
+                    .school_id(null)
+                    .school_name(null)
+                    .score(0)
+                    .school_rank(null)
+                    .school_percentile(null)
+                    .build();
+        }
+
+        long sid = me.getSchool().getSchoolId();
+        var z = redis.opsForZSet();
+
+        Long zeroBased = z.reverseRank(SCHOOLS_KEY, memberSchool(sid));
+        Double score = z.score(SCHOOLS_KEY, memberSchool(sid));
+        Long total = z.zCard(SCHOOLS_KEY);
+
+        Integer rank1 = zeroBased == null ? null : (int)(zeroBased + 1);
+        long schoolTotal = score == null ? 0L : score.longValue();
+
+        Double pct = bottomPercentile(rank1, total);
+
+        return MySchoolVsSchoolResponse.builder()
+                .user_id(userId)
+                .school_id(sid)
+                .school_name(me.getSchool().getSchoolName())
+                .score(schoolTotal)              // 우리 학교 총합 점수
+                .school_rank(rank1)
+                .school_percentile(pct)
+                .build();
+    }
+
+    // Util method
+    private static String memberUser(long userId) {
+        return "u:" + userId;
+    }
+    private static long parseUserId(String m) {
+        return Long.parseLong(m.substring(2));
+    }
+    private static String memberSchool(long schoolId) {
+        return "s:" + schoolId;
+    }
+    private static String schoolKey(long schoolId) {
+        return String.format(SCHOOL_KEY_FMT, schoolId);
+    }
+    private static Double bottomPercentile(Integer rank1Based, Long total) {
+        if (rank1Based == null || total == null || total <= 0) return null;
+        double p = ((rank1Based - 1) / (double) total) * 100.0;
+        return Math.round(p * 10.0) / 10.0;
+    }
+}

--- a/gogildong/src/main/resources/application.yml
+++ b/gogildong/src/main/resources/application.yml
@@ -14,3 +14,8 @@ spring:
     secret: ${JWT_SECRET}
     access-ttl: 900000
     refresh-ttl: 604800000
+
+  data:
+    redis:
+      host: localhost
+      port: ${REDIS_PORT}


### PR DESCRIPTION
## 연관 이슈

close #24 

<br/>

## 개요

랭킹 관련 api 구현

<br/>

## 📌 구현 기능

- [x] Redis 설정
- [x] 전체 개인 랭킹 조회
- [x] 전체에서 내 랭킹 조회
- [x] 교내 전체 랭킹 조회
- [x] 교내에서 내 랭킹 조회
- [x] 전체 학교별 랭킹 조회
- [x] 우리 학교 랭킹 조회

<br/>
  
## ⚠️ 참고 사항 및 주의할 점
- application.yml에 redis port 추가하였습니다. 사용하시는 redis port 구성 편집에 적어주세요!
- 사용자 포인트 증감 시 redis 업데이트를 위해 `rankService.upsertUserScore(user.getUserId(), user.getTotal_score());` 메서드 호출 부탁드립니다!
- ranking에서 rank로 api uri pattern 변경하였습니다. API 명세서에 업데이트해두었으니 확인 부탁드립니다!
- API 명세서에 Postman 응답 이미지 첨부해두었습니다! 


<br/>
