### PR TITLE
feat(#52): 제보 조회 api

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/global/exception/ClientExceptionCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/exception/ClientExceptionCode.java
@@ -29,6 +29,7 @@ public enum ClientExceptionCode {
 
     // 제보
     DOOR_TYPE_BAD_REQUEST,
+    RESTROOMREPORT_NOT_FOUND,
 
     // 허가
     UNAUTHORIZED_SCHOOL_ACCESS,

--- a/gogildong/src/main/java/com/efub/gogildong/global/exception/ExceptionCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/exception/ExceptionCode.java
@@ -33,6 +33,7 @@ public enum ExceptionCode {
 
     // 제보
     DOOR_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST, ClientExceptionCode.DOOR_TYPE_BAD_REQUEST, "유효하지 않은 문 타입입니다."),
+    RESTROOMREPORT_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.RESTROOMREPORT_NOT_FOUND, "존재하지 않는 화장실 제보입니다."),
 
     // 허가
     UNAUTHORIZED_SCHOOL_ACCESS(HttpStatus.UNAUTHORIZED, ClientExceptionCode.UNAUTHORIZED_SCHOOL_ACCESS, "허가되지 않은 사용자가 학교 정보에 접근했습니다."),

--- a/gogildong/src/main/java/com/efub/gogildong/reports/controller/ReportController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/controller/ReportController.java
@@ -2,6 +2,7 @@ package com.efub.gogildong.reports.controller;
 
 import com.efub.gogildong.reports.dto.request.NewRestRoomReportRequest;
 import com.efub.gogildong.reports.dto.request.RestRoomReportRequest;
+import com.efub.gogildong.reports.dto.response.ReportListResponse;
 import com.efub.gogildong.reports.dto.response.RestRoomReportResponse;
 import com.efub.gogildong.reports.service.ReportService;
 import jakarta.validation.Valid;
@@ -39,13 +40,22 @@ public class ReportController {
     }
 
     /*
-     * 화장실 제보를 상세 조회합니다. (학교 관리인)
-     * */
+    화장실 제보를 상세 조회합니다. (학교 관리자)
+     */
     @GetMapping("/restroom/{restRoomReportId}")
     public ResponseEntity<RestRoomReportResponse> getRestRoomReport(@PathVariable("restRoomReportId") Long restRoomReportId,
                                                                     Authentication authentication) {
         reportService.getRestRoomReport(restRoomReportId);
         return ResponseEntity.ok(reportService.getRestRoomReport(restRoomReportId));
     }
+
+    /*
+    제보 전체 목록을 조회합니다. (학교 관리자)
+     */
+    @GetMapping(" ")
+    public ResponseEntity<ReportListResponse> getAllReport() {
+        return ResponseEntity.ok(reportService.getAllReports());
+    }
+
 
 }

--- a/gogildong/src/main/java/com/efub/gogildong/reports/controller/ReportController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/controller/ReportController.java
@@ -2,16 +2,14 @@ package com.efub.gogildong.reports.controller;
 
 import com.efub.gogildong.reports.dto.request.NewRestRoomReportRequest;
 import com.efub.gogildong.reports.dto.request.RestRoomReportRequest;
+import com.efub.gogildong.reports.dto.response.RestRoomReportResponse;
 import com.efub.gogildong.reports.service.ReportService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/reports")
@@ -40,5 +38,14 @@ public class ReportController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    /*
+     * 화장실 제보를 상세 조회합니다. (학교 관리인)
+     * */
+    @GetMapping("/restroom/{restRoomReportId}")
+    public ResponseEntity<RestRoomReportResponse> getRestRoomReport(@PathVariable("restRoomReportId") Long restRoomReportId,
+                                                                    Authentication authentication) {
+        reportService.getRestRoomReport(restRoomReportId);
+        return ResponseEntity.ok(reportService.getRestRoomReport(restRoomReportId));
+    }
 
 }

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/ReportListResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/ReportListResponse.java
@@ -1,0 +1,19 @@
+package com.efub.gogildong.reports.dto.response;
+
+import com.efub.gogildong.reports.dto.summary.ReportSummary;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ReportListResponse {
+
+    private List<ReportSummary> reports;
+
+    public ReportListResponse(List<ReportSummary> reports) {
+        this.reports = reports;
+    }
+
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/RestRoomReportResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/RestRoomReportResponse.java
@@ -1,0 +1,42 @@
+package com.efub.gogildong.reports.dto.response;
+
+import com.efub.gogildong.facility.domain.DoorType;
+import com.efub.gogildong.facility.domain.GenderType;
+import com.efub.gogildong.reports.domain.RestRoomReport;
+import com.efub.gogildong.user.dto.response.UserResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RestRoomReportResponse {
+
+    private Long reportId;
+    private Long restroomReportId;
+    private UserResponseDto user;
+    private String restroomReportImage;
+    private GenderType gender;
+    private Boolean isAccessible;
+    private DoorType doorType;
+    private Float doorWidth;
+    private Float doorHeight;
+    private Float toiletHeight;
+    private Boolean grabBar;
+
+    public static RestRoomReportResponse from(RestRoomReport restRoomReport) {
+        return RestRoomReportResponse.builder()
+                .reportId(restRoomReport.getReport().getReportId())
+                .restroomReportId(restRoomReport.getRestroomReportId())
+                .user(UserResponseDto.from(restRoomReport.getReport().getUser()))
+                .restroomReportImage(restRoomReport.getRestroomReportImage())
+                .gender(restRoomReport.getGender())
+                .isAccessible(restRoomReport.getIsAccessible())
+                .doorType(restRoomReport.getDoorType())
+                .doorWidth(restRoomReport.getDoorWidth())
+                .doorHeight(restRoomReport.getDoorHeight())
+                .toiletHeight(restRoomReport.getToiletHeight())
+                .grabBar(restRoomReport.getGrabBar())
+                .build();
+    }
+
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/summary/ReportSummary.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/summary/ReportSummary.java
@@ -1,0 +1,26 @@
+package com.efub.gogildong.reports.dto.summary;
+
+import com.efub.gogildong.reports.domain.Report;
+import com.efub.gogildong.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReportSummary {
+
+    private Long reportId;
+    private int flagCount;
+    private Boolean isPublic;
+    private String loginId;
+
+    public static ReportSummary from(Report report) {
+        if (report == null) return null;
+        return ReportSummary.builder()
+                .reportId(report.getReportId())
+                .flagCount(report.getFlagCount())
+                .isPublic(report.getIsPublic())
+                .loginId(report.getUser().getLoginId())
+                .build();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/repository/ReportRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/repository/ReportRepository.java
@@ -3,5 +3,10 @@ package com.efub.gogildong.reports.repository;
 import com.efub.gogildong.reports.domain.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    // 최신순으로 모든 제보 불러오기
+    List<Report> findByOrderByCreatedAtDesc();
 }

--- a/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
@@ -11,8 +11,10 @@ import com.efub.gogildong.reports.domain.Report;
 import com.efub.gogildong.reports.domain.RestRoomReport;
 import com.efub.gogildong.reports.dto.request.NewRestRoomReportRequest;
 import com.efub.gogildong.reports.dto.request.RestRoomReportRequest;
+import com.efub.gogildong.reports.dto.response.ReportListResponse;
 import com.efub.gogildong.reports.dto.response.RestRoomAggregateStat;
 import com.efub.gogildong.reports.dto.response.RestRoomReportResponse;
+import com.efub.gogildong.reports.dto.summary.ReportSummary;
 import com.efub.gogildong.reports.repository.ReportRepository;
 import com.efub.gogildong.reports.repository.RestRoomReportRepository;
 import com.efub.gogildong.user.domain.User;
@@ -155,11 +157,23 @@ public class ReportService {
         restroom.updateAggregate(stat);
     }
 
-    // 화장실 제보 조회 (학교 관리자)
+    /*
+    화장실 제보 조회 (학교 관리자)
+     */
     @Transactional(readOnly = true)
     public RestRoomReportResponse getRestRoomReport(Long restRoomReportId) {
         RestRoomReport restRoomReport = restRoomReportRepository.findById(restRoomReportId)
                 .orElseThrow(() -> new GoGildongException(ExceptionCode.RESTROOMREPORT_NOT_FOUND));
         return RestRoomReportResponse.from(restRoomReport);
+    }
+
+    /*
+    제보 목록 조회 (학교 관리자)
+     */
+    @Transactional(readOnly = true)
+    public ReportListResponse getAllReports() {
+        List<ReportSummary> reportSummaries = reportRepository.findByOrderByCreatedAtDesc().stream()
+                .map(ReportSummary::from).toList();
+        return new ReportListResponse(reportSummaries);
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
@@ -12,6 +12,7 @@ import com.efub.gogildong.reports.domain.RestRoomReport;
 import com.efub.gogildong.reports.dto.request.NewRestRoomReportRequest;
 import com.efub.gogildong.reports.dto.request.RestRoomReportRequest;
 import com.efub.gogildong.reports.dto.response.RestRoomAggregateStat;
+import com.efub.gogildong.reports.dto.response.RestRoomReportResponse;
 import com.efub.gogildong.reports.repository.ReportRepository;
 import com.efub.gogildong.reports.repository.RestRoomReportRepository;
 import com.efub.gogildong.user.domain.User;
@@ -152,5 +153,13 @@ public class ReportService {
 
         // 4) Restroom update
         restroom.updateAggregate(stat);
+    }
+
+    // 화장실 제보 조회 (학교 관리자)
+    @Transactional(readOnly = true)
+    public RestRoomReportResponse getRestRoomReport(Long restRoomReportId) {
+        RestRoomReport restRoomReport = restRoomReportRepository.findById(restRoomReportId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.RESTROOMREPORT_NOT_FOUND));
+        return RestRoomReportResponse.from(restRoomReport);
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/response/UserResponseDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/response/UserResponseDto.java
@@ -1,0 +1,34 @@
+package com.efub.gogildong.user.dto.response;
+
+import com.efub.gogildong.schools.domain.School;
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.domain.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponseDto {
+    private Long userId;
+    private String loginId;
+    private String username;
+    private UserRole role;
+    private String email;
+    private String phone;
+    private String schoolCode;
+    private String schoolName;
+
+    public static UserResponseDto from(User user) {
+        School s = user.getSchool();
+        return UserResponseDto.builder()
+                .userId(user.getUserId())
+                .loginId(user.getLoginId())
+                .username(user.getUsername())
+                .role(user.getRole())
+                .email(user.getEmail())
+                .phone(user.getPhone())
+                .schoolCode(s != null ? s.getSchoolCode() : null)
+                .schoolName(s != null ? s.getSchoolName() : null)
+                .build();
+    }
+}


### PR DESCRIPTION
## 연관 이슈

close #52

<br/>

## 개요

- 학교 관리자가 제보 전체 목록을 조회하고, 화장실 제보의 상제 정보를 조회합니다.

<br/>

## 📌 구현 기능

- [x] 화장실 제보 상세 조회 api
  <img width="1916" height="1272" alt="image" src="https://github.com/user-attachments/assets/43f1d6a8-d40f-4cc1-b65d-1bb92574b6e4" />

- [x] 제보 목록 조회 api
  <img width="1918" height="1084" alt="image" src="https://github.com/user-attachments/assets/a4ae92fe-9b2b-4110-9849-fb7ae2034e4f" />



