### PR TITLE
feat(#25) Quiz 조회, 제출 api 및 Point 증감 메서드 구현

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/global/exception/ClientExceptionCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/exception/ClientExceptionCode.java
@@ -36,5 +36,12 @@ public enum ClientExceptionCode {
     // 사용자
     USER_NOT_FOUND,
     ACCESS_DENIED,
-    INVALID_PASSWORD
+    INVALID_PASSWORD,
+
+    // 랭크
+    RANK_NOT_FOUND,
+    USER_HAS_NO_SCHOOL,
+
+    // Redis
+    REDIS_OPERATION_FAILED
 }

--- a/gogildong/src/main/java/com/efub/gogildong/global/exception/ExceptionCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/exception/ExceptionCode.java
@@ -40,8 +40,14 @@ public enum ExceptionCode {
     // 사용자
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."),
     ACCESS_DENIED(HttpStatus.UNAUTHORIZED, ClientExceptionCode.ACCESS_DENIED, "접근이 허용되지 않습니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED,ClientExceptionCode.INVALID_PASSWORD, "비밀번호가 일치하지 않습니다.");
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED,ClientExceptionCode.INVALID_PASSWORD, "비밀번호가 일치하지 않습니다."),
 
+    // 랭크
+    RANK_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.RANK_NOT_FOUND, "랭킹 정보를 찾을 수 없습니다."),
+    USER_HAS_NO_SCHOOL(HttpStatus.BAD_REQUEST, ClientExceptionCode.USER_HAS_NO_SCHOOL, "소속된 학교가 없습니다."),
+
+    // Redis
+    REDIS_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, ClientExceptionCode.REDIS_OPERATION_FAILED, "Redis 연산 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final ClientExceptionCode clientExceptionCode;

--- a/gogildong/src/main/java/com/efub/gogildong/point/controller/PointController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/point/controller/PointController.java
@@ -1,0 +1,71 @@
+package com.efub.gogildong.point.controller;
+
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
+import com.efub.gogildong.point.service.PointService;
+import com.efub.gogildong.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/point")
+@RequiredArgsConstructor
+public class PointController {
+
+    private final PointService pointService;
+    private final UserService userService;
+
+    /* GET /point : 사용자 포인트 조회 */
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public Map<String, Object> getMyPoints(Authentication authentication) {
+        String loginId = authentication.getName();
+        if (loginId == null || loginId.isBlank()) {
+            throw new GoGildongException(ExceptionCode.UNAUTHORIZED_ACCESS);
+        }
+
+        long userId = userService.getUserByLoginId(loginId).getUserId();
+        int total = pointService.getTotalPoints(userId);
+        return Map.of("user_id", userId, "totalPoints", total);
+    }
+
+    /* POST /point/add : 포인트 수동 추가 */
+    @PostMapping("/add")
+    @PreAuthorize("isAuthenticated()")
+    public Map<String, Object> addPoints(
+            @RequestParam int amount,
+            Authentication authentication
+    ) {
+        if (amount <= 0) {
+            throw new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT);
+        }
+
+        String loginId = authentication.getName();
+        long userId = userService.getUserByLoginId(loginId).getUserId();
+
+        int updated = pointService.addPoints(userId, amount);
+        return Map.of("user_id", userId, "added", amount, "totalPoints", updated);
+    }
+
+    /* POST /point/deduct : 포인트 수동 차감 */
+    @PostMapping("/deduct")
+    @PreAuthorize("isAuthenticated()")
+    public Map<String, Object> deductPoints(
+            @RequestParam int amount,
+            Authentication authentication
+    ) {
+        if (amount <= 0) {
+            throw new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT);
+        }
+
+        String loginId = authentication.getName();
+        long userId = userService.getUserByLoginId(loginId).getUserId();
+
+        int updated = pointService.deductPoints(userId, amount);
+        return Map.of("user_id", userId, "deducted", amount, "totalPoints", updated);
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/point/service/PointService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/point/service/PointService.java
@@ -1,0 +1,68 @@
+package com.efub.gogildong.point.service;
+
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
+import com.efub.gogildong.rank.service.RankService;
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PointService {
+
+    private final UserRepository userRepository;
+    private final RankService rankService;
+
+    // Point 추가
+    @Transactional
+    public int addPoints(Long userId, int amount) {
+        if (userId == null) {
+            throw new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+
+        int before = user.getTotal_score();
+        int after = before + amount;
+
+        user.setTotal_score(after);
+        rankService.upsertUserScore(userId, after);
+
+        return after;
+    }
+
+    // Point 차감
+    @Transactional
+    public int deductPoints(Long userId, int amount) {
+        if (userId == null) {
+            throw new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+
+        int before = user.getTotal_score();
+        int after = Math.max(0, before - amount);
+
+        user.setTotal_score(after);
+        rankService.upsertUserScore(userId, after);
+
+        return after;
+    }
+
+    // 사용자 포인트 조회
+    @Transactional(readOnly = true)
+    public int getTotalPoints(Long userId) {
+        if (userId == null) {
+            throw new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+        return user.getTotal_score();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/controller/QuizController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/controller/QuizController.java
@@ -1,0 +1,73 @@
+package com.efub.gogildong.quiz.controller;
+
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
+import com.efub.gogildong.quiz.dto.request.SubmitQuizRequest;
+import com.efub.gogildong.quiz.dto.response.QuizDetailResponse;
+import com.efub.gogildong.quiz.dto.response.QuizListResponse;
+import com.efub.gogildong.quiz.service.QuizCommandService;
+import com.efub.gogildong.quiz.service.QuizQueryService;
+import com.efub.gogildong.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/quiz")
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizQueryService quizQueryService;
+    private final QuizCommandService quizCommandService;
+    private final UserService userService;
+
+    /* GET /quiz : 전체 퀴즈 목록 */
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public QuizListResponse getAll(Authentication authentication) {
+        String loginId = authentication.getName();
+        if (loginId == null || loginId.isBlank()) {
+            throw new GoGildongException(ExceptionCode.UNAUTHORIZED_ACCESS);
+        }
+
+        long userId = userService.getUserByLoginId(loginId).getUserId();
+        return quizQueryService.getAllQuizzes(userId);
+    }
+
+    /* GET /quiz/{quizId} : 퀴즈 상세 */
+    @GetMapping("/{quizId}")
+    @PreAuthorize("isAuthenticated()")
+    public QuizDetailResponse getOne(
+            @PathVariable Long quizId,
+            Authentication authentication
+    ) {
+        if (quizId == null) {
+            throw new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT);
+        }
+
+        String loginId = authentication.getName();
+        long userId = userService.getUserByLoginId(loginId).getUserId();
+        return quizQueryService.getQuizDetail(quizId, userId);
+    }
+
+    /* POST /quiz/{quizId} 퀴즈 제출 */
+    @PostMapping("/{quizId}")
+    @PreAuthorize("isAuthenticated()")
+    public Map<String, Object> submit(
+            @PathVariable Long quizId,
+            @RequestBody SubmitQuizRequest request,
+            Authentication authentication
+    ) {
+        if (quizId == null) {
+            throw new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT);
+        }
+
+        String loginId = authentication.getName();
+        Long userId = userService.getUserByLoginId(loginId).getUserId();
+        return quizCommandService.submit(quizId, userId, request);
+    }
+
+}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/domain/Quiz.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/domain/Quiz.java
@@ -1,0 +1,32 @@
+package com.efub.gogildong.quiz.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Quiz {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String question;
+
+    @OneToOne
+    @JoinColumn(name = "correct_choice_id")
+    private QuizChoice correctChoice;
+
+    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<QuizChoice> choices;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/domain/QuizAttempt.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/domain/QuizAttempt.java
@@ -1,0 +1,55 @@
+package com.efub.gogildong.quiz.domain;
+
+import com.efub.gogildong.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "quiz_attempt",
+        uniqueConstraints = @UniqueConstraint(name = "uq_attempt_user_quiz", columnNames = {"user_id","quiz_id"}))
+public class QuizAttempt {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private Quiz quiz;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "selected_choice_id", nullable = false)
+    private QuizChoice selectedChoice;
+
+    @Column(nullable = false)
+    private Boolean isCorrect;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateAnswer(QuizChoice newChoice, boolean correct) {
+        this.selectedChoice = newChoice;
+        this.isCorrect = correct;
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/domain/QuizChoice.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/domain/QuizChoice.java
@@ -1,0 +1,26 @@
+package com.efub.gogildong.quiz.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class QuizChoice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id", nullable = false)
+    private Quiz quiz;
+
+    private String label;   // A, B, C, D
+    private String text;    // 보기 내용
+
+    @Column(columnDefinition = "TEXT")
+    private String description; // 보기 해설
+}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/dto/AttemptBrief.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/dto/AttemptBrief.java
@@ -1,0 +1,7 @@
+package com.efub.gogildong.quiz.dto;
+
+public record AttemptBrief(
+        String attemptStatus,
+        Long selectedChoiceId,
+        Boolean isCorrect
+) {}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/dto/ChoiceDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/dto/ChoiceDto.java
@@ -1,0 +1,3 @@
+package com.efub.gogildong.quiz.dto;
+
+public record ChoiceDto(Long choice_id, String label, String text) {}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/dto/QuizListItemDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/dto/QuizListItemDto.java
@@ -1,0 +1,8 @@
+package com.efub.gogildong.quiz.dto;
+
+public record QuizListItemDto(
+        Long quiz_id,
+        String title,
+        String attemptStatus,
+        Boolean isCorrect
+) {}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/dto/request/SubmitQuizRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/dto/request/SubmitQuizRequest.java
@@ -1,0 +1,3 @@
+package com.efub.gogildong.quiz.dto.request;
+
+public record SubmitQuizRequest(String selectedLabel) {}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/dto/response/QuizDetailResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/dto/response/QuizDetailResponse.java
@@ -1,0 +1,14 @@
+package com.efub.gogildong.quiz.dto.response;
+
+import com.efub.gogildong.quiz.dto.AttemptBrief;
+import com.efub.gogildong.quiz.dto.ChoiceDto;
+
+import java.util.List;
+
+public record QuizDetailResponse(
+        Long quiz_id,
+        String title,
+        String question,
+        List<ChoiceDto> choices,
+        AttemptBrief attempt
+) {}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/dto/response/QuizListResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/dto/response/QuizListResponse.java
@@ -1,0 +1,6 @@
+package com.efub.gogildong.quiz.dto.response;
+
+import com.efub.gogildong.quiz.dto.QuizListItemDto;
+import java.util.List;
+
+public record QuizListResponse(List<QuizListItemDto> quizzes) {}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/dto/response/SubmitQuizResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/dto/response/SubmitQuizResponse.java
@@ -1,0 +1,23 @@
+package com.efub.gogildong.quiz.dto.response;
+
+import java.util.List;
+
+public record SubmitQuizResponse(
+        Long attempt_id,
+        Long quiz_id,
+        Long user_id,
+        boolean isCorrect,
+        String status,
+        String finishedAt,
+        int point,
+        List<WrongAnswerItem> answers // 오답일 때만 사용
+) {
+    public record WrongAnswerItem(
+            Long quiz_id,
+            String question,
+            String selected_answer,
+            String correct_answer,
+            boolean is_correct,
+            String explanation
+    ) {}
+}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/repository/QuizAttemptRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/repository/QuizAttemptRepository.java
@@ -1,0 +1,10 @@
+package com.efub.gogildong.quiz.repository;
+
+import com.efub.gogildong.quiz.domain.QuizAttempt;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface QuizAttemptRepository extends JpaRepository<QuizAttempt, Long> {
+    Optional<QuizAttempt> findByUser_UserIdAndQuiz_Id(Long userId, Long quizId);
+}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/repository/QuizChoiceRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/repository/QuizChoiceRepository.java
@@ -1,0 +1,23 @@
+package com.efub.gogildong.quiz.repository;
+
+import com.efub.gogildong.quiz.domain.QuizChoice;
+import com.efub.gogildong.quiz.dto.ChoiceDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QuizChoiceRepository extends JpaRepository<QuizChoice, Long> {
+
+    @Query("""
+    select new com.efub.gogildong.quiz.dto.ChoiceDto(c.id, c.label, c.text)
+    from QuizChoice c
+    where c.quiz.id = :quizId
+    order by c.label asc
+    """)
+    List<ChoiceDto> findDtosByQuizId(@Param("quizId") Long quizId);
+
+    Optional<QuizChoice> findByQuiz_IdAndLabel(Long quizId, String label);
+}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/repository/QuizRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/repository/QuizRepository.java
@@ -1,0 +1,27 @@
+package com.efub.gogildong.quiz.repository;
+
+import com.efub.gogildong.quiz.domain.Quiz;
+import com.efub.gogildong.quiz.dto.QuizListItemDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+
+    // 목록 조회: 응시 레코드 존재 여부로 attemptStatus/isCorrect 계산
+    @Query("""
+    select new com.efub.gogildong.quiz.dto.QuizListItemDto(
+      q.id,
+      q.title,
+      case when a.id is null then 'NONE' else 'SUBMITTED' end,
+      a.isCorrect
+    )
+    from Quiz q
+    left join QuizAttempt a
+      on a.quiz.id = q.id and a.user.id = :userId
+    order by q.id asc
+    """)
+    List<QuizListItemDto> findAllWithAttempt(@Param("userId") Long userId);
+}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/service/QuizCommandService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/service/QuizCommandService.java
@@ -1,0 +1,87 @@
+package com.efub.gogildong.quiz.service;
+
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
+import com.efub.gogildong.point.service.PointService;
+import com.efub.gogildong.quiz.domain.Quiz;
+import com.efub.gogildong.quiz.domain.QuizAttempt;
+import com.efub.gogildong.quiz.domain.QuizChoice;
+import com.efub.gogildong.quiz.dto.request.SubmitQuizRequest;
+import com.efub.gogildong.quiz.repository.QuizAttemptRepository;
+import com.efub.gogildong.quiz.repository.QuizChoiceRepository;
+import com.efub.gogildong.quiz.repository.QuizRepository;
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class QuizCommandService {
+
+    private final QuizRepository quizRepository;
+    private final QuizAttemptRepository quizAttemptRepository;
+    private final UserRepository userRepository;
+    private final QuizChoiceRepository quizChoiceRepository;
+    private final PointService pointService;
+
+    private static final int CORRECT_POINT = 20;
+
+    @Transactional
+    public Map<String, Object> submit(Long quizId, Long userId, SubmitQuizRequest req) {
+        if (quizId == null || userId == null) {
+            throw new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT);
+        }
+        if (req == null || req.selectedLabel() == null || req.selectedLabel().isBlank()) {
+            throw new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT);
+        }
+
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT));
+
+        String selected = req.selectedLabel().trim().toUpperCase();
+        QuizChoice chosen = quizChoiceRepository.findByQuiz_IdAndLabel(quizId, selected)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.ILLEGAL_ARGUMENT));
+
+        boolean isCorrect = quiz.getCorrectChoice().getLabel().equalsIgnoreCase(selected);
+
+        QuizAttempt attempt = quizAttemptRepository.findByUser_UserIdAndQuiz_Id(userId, quizId)
+                .map(a -> {
+                    a.updateAnswer(chosen, isCorrect);
+                    return a;
+                })
+                .orElseGet(() -> quizAttemptRepository.save(
+                        QuizAttempt.builder()
+                                .quiz(quiz)
+                                .user(userRepository.getReferenceById(userId))
+                                .selectedChoice(chosen)
+                                .isCorrect(isCorrect)
+                                .build()
+                ));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+
+        Map<String, Object> resp = new LinkedHashMap<>();
+        if (isCorrect) {
+            int total = pointService.addPoints(userId, CORRECT_POINT);
+            resp.put("isCorrect", true);
+            resp.put("point", CORRECT_POINT);
+            resp.put("totalPoints", total);
+        } else {
+            resp.put("isCorrect", false);
+            resp.put("correctAnswer", quiz.getCorrectChoice().getLabel());
+            resp.put("selectedAnswer", selected);
+            for (QuizChoice c : quiz.getChoices()) {
+                String key = "description" + c.getLabel();
+                String desc = (c.getDescription() == null || c.getDescription().isBlank()) ? "" : c.getDescription();
+                resp.put(key, desc);
+            }
+        }
+        return resp;
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/service/QuizQueryService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/service/QuizQueryService.java
@@ -1,0 +1,54 @@
+package com.efub.gogildong.quiz.service;
+
+import com.efub.gogildong.quiz.domain.Quiz;
+import com.efub.gogildong.quiz.dto.AttemptBrief;
+import com.efub.gogildong.quiz.dto.ChoiceDto;
+import com.efub.gogildong.quiz.dto.QuizListItemDto;
+import com.efub.gogildong.quiz.dto.response.QuizDetailResponse;
+import com.efub.gogildong.quiz.dto.response.QuizListResponse;
+import com.efub.gogildong.quiz.repository.QuizAttemptRepository;
+import com.efub.gogildong.quiz.repository.QuizChoiceRepository;
+import com.efub.gogildong.quiz.repository.QuizRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizQueryService {
+
+    private final QuizRepository quizRepository;
+    private final QuizChoiceRepository quizChoiceRepository;
+    private final QuizAttemptRepository quizAttemptRepository;
+
+    // GET /quiz : 전체 퀴즈 목록
+    public QuizListResponse getAllQuizzes(Long userId) {
+        List<QuizListItemDto> items = quizRepository.findAllWithAttempt(userId);
+        return new QuizListResponse(items);
+    }
+
+    // GET /quiz/{quizId} : 퀴즈 상세
+    public QuizDetailResponse getQuizDetail(Long quizId, Long userId) {
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 퀴즈가 존재하지 않습니다."));
+
+        List<ChoiceDto> choices = quizChoiceRepository.findDtosByQuizId(quizId);
+
+        AttemptBrief attempt = quizAttemptRepository.findByUser_UserIdAndQuiz_Id(userId, quizId)
+                .map(a -> new AttemptBrief("SUBMITTED",
+                        a.getSelectedChoice().getId(),
+                        a.getIsCorrect()))
+                .orElse(new AttemptBrief("NONE", null, null));
+
+        return new QuizDetailResponse(
+                quiz.getId(),
+                quiz.getTitle(),
+                quiz.getQuestion(),
+                choices,
+                attempt
+        );
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/rank/controller/RankController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/controller/RankController.java
@@ -1,5 +1,7 @@
 package com.efub.gogildong.rank.controller;
 
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
 import com.efub.gogildong.rank.dto.response.*;
 import com.efub.gogildong.rank.service.RankService;
 import com.efub.gogildong.user.service.UserService;
@@ -16,15 +18,19 @@ public class RankController {
     private final RankService rankService;
     private final UserService userService;
 
-    /* Redis Test용 API */
+    /* Redis Test용 API, Super Admin 권한 줘야 사용할 수 있게 변경하는 게 좋을 듯 */
     @PostMapping("/rebuild")
     public void rebuild() {
-        rankService.rebuildAllRanksFromDB();
+        try {
+            rankService.rebuildAllRanksFromDB();
+        } catch (Exception e) {
+            throw new GoGildongException(ExceptionCode.REDIS_OPERATION_FAILED);
+        }
     }
 
     /* GET /rank : 전체 랭킹 조회 (상위 100) */
     @GetMapping
-    @PreAuthorize("isAuthenticated()") // 명세: access token 필요
+    @PreAuthorize("isAuthenticated()")
     public GlobalRankListResponse getGlobal(Authentication authentication) {
         return rankService.getGlobalTop();
     }
@@ -34,24 +40,36 @@ public class RankController {
     @PreAuthorize("isAuthenticated()")
     public MyGlobalRankResponse getMyGlobal(Authentication authentication) {
         String loginId = authentication.getName();
+        if (loginId == null || loginId.isBlank()) {
+            throw new GoGildongException(ExceptionCode.UNAUTHORIZED_ACCESS);
+        }
+
         long userId = userService.getUserByLoginId(loginId).getUserId();
         return rankService.getMyGlobalRank(userId);
     }
 
     /* GET /rank/school : 교내 전체 랭킹 조회 */
     @GetMapping("/school")
-    @PreAuthorize("isAuthenticated()") // 명세: access token 필요
+    @PreAuthorize("isAuthenticated()")
     public GlobalRankListResponse getSchool(Authentication authentication) {
         String loginId = authentication.getName();
+        if (loginId == null || loginId.isBlank()) {
+            throw new GoGildongException(ExceptionCode.UNAUTHORIZED_ACCESS);
+        }
+
         long userId = userService.getUserByLoginId(loginId).getUserId();
         return rankService.getSchoolTopByUser(userId);
     }
 
-    /* GET /rank/school/mine : 교내에서 내 랭킹 조회 */
+    /* GET /rank/school/mine : 교내 내 랭킹 조회 */
     @GetMapping("/school/mine")
     @PreAuthorize("isAuthenticated()")
     public SchoolMyRankResponse getMySchool(Authentication authentication) {
         String loginId = authentication.getName();
+        if (loginId == null || loginId.isBlank()) {
+            throw new GoGildongException(ExceptionCode.UNAUTHORIZED_ACCESS);
+        }
+
         long userId = userService.getUserByLoginId(loginId).getUserId();
         return rankService.getMySchoolRank(userId);
     }
@@ -59,15 +77,19 @@ public class RankController {
     /* GET /rank/schools : 전체 학교별 랭킹 */
     @GetMapping("/schools")
     @PreAuthorize("isAuthenticated()")
-    public SchoolRankListResponse getSchools(Authentication authentication) {
+    public SchoolRankListResponse getSchools() {
         return rankService.getSchoolsBoard();
     }
 
-    /* GET /rank/schools/mine : 우리 학교의 학교랭킹 */
+    /* GET /rank/schools/mine : 내 학교의 학교랭킹 */
     @GetMapping("/schools/mine")
     @PreAuthorize("isAuthenticated()")
     public MySchoolVsSchoolResponse getMySchoolVsSchool(Authentication authentication) {
         String loginId = authentication.getName();
+        if (loginId == null || loginId.isBlank()) {
+            throw new GoGildongException(ExceptionCode.UNAUTHORIZED_ACCESS);
+        }
+
         long userId = userService.getUserByLoginId(loginId).getUserId();
         return rankService.getMySchoolVsSchoolRank(userId);
     }

--- a/gogildong/src/main/java/com/efub/gogildong/rank/service/RankService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/rank/service/RankService.java
@@ -1,5 +1,7 @@
 package com.efub.gogildong.rank.service;
 
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
 import com.efub.gogildong.rank.dto.GlobalRankItemDto;
 import com.efub.gogildong.rank.dto.SchoolRankItemDto;
 import com.efub.gogildong.rank.dto.response.*;
@@ -8,6 +10,7 @@ import com.efub.gogildong.schools.repository.SchoolRepository;
 import com.efub.gogildong.user.domain.User;
 import com.efub.gogildong.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
@@ -33,273 +36,302 @@ public class RankService {
     // Redis Rebuild
     @Transactional
     public void rebuildAllRanksFromDB() {
-        // 0) 기존 키 정리
-        redis.delete(GLOBAL_KEY);
-        redis.delete(SCHOOLS_KEY);
-        var schoolKeys = redis.keys("rank:school:*");
-        if (!schoolKeys.isEmpty()) redis.delete(schoolKeys);
+        try {
+            // 0) 기존 키 정리
+            redis.delete(GLOBAL_KEY);
+            redis.delete(SCHOOLS_KEY);
+            var schoolKeys = redis.keys("rank:school:*");
+            if (!schoolKeys.isEmpty()) redis.delete(schoolKeys);
 
-        // 1) 전체 유저를 돌며 글로벌/교내 채우고, 학교 합계를 누적
-        var z = redis.opsForZSet();
-        Map<Long, Long> schoolSum = new HashMap<>();
+            // 1) 전체 유저를 돌며 글로벌/교내 채우고, 학교 합계를 누적
+            var z = redis.opsForZSet();
+            Map<Long, Long> schoolSum = new HashMap<>();
 
-        userRepository.findAll().forEach(u -> {
-            long uid = u.getUserId();
-            long score = u.getTotal_score();
-            z.add(GLOBAL_KEY, memberUser(uid), score);
+            userRepository.findAll().forEach(u -> {
+                long uid = u.getUserId();
+                long score = u.getTotal_score();
+                z.add(GLOBAL_KEY, memberUser(uid), score);
 
-            var school = u.getSchool();
-            if (school != null) {
-                long sid = school.getSchoolId();
-                z.add(schoolKey(sid), memberUser(uid), score);
-                schoolSum.merge(sid, score, Long::sum);
-            }
-        });
+                var school = u.getSchool();
+                if (school != null) {
+                    long sid = school.getSchoolId();
+                    z.add(schoolKey(sid), memberUser(uid), score);
+                    schoolSum.merge(sid, score, Long::sum);
+                }
+            });
 
-        schoolSum.forEach((sid, sum) -> z.add(SCHOOLS_KEY, memberSchool(sid), sum));
+            schoolSum.forEach((sid, sum) -> z.add(SCHOOLS_KEY, memberSchool(sid), sum));
+        } catch (DataAccessException e) {
+            throw new GoGildongException(ExceptionCode.REDIS_OPERATION_FAILED);
+        }
     }
 
     // 사용자 점수 upsert
     @Transactional
     public void upsertUserScore(long userId, long newScore) {
-        var z = redis.opsForZSet();
+        try {
+            var z = redis.opsForZSet();
 
-        Double prev = z.score(GLOBAL_KEY, memberUser(userId));
-        double oldScore = prev == null ? 0d : prev;
+            Double prev = z.score(GLOBAL_KEY, memberUser(userId));
+            double oldScore = prev == null ? 0d : prev;
 
-        z.add(GLOBAL_KEY, memberUser(userId), newScore);
+            z.add(GLOBAL_KEY, memberUser(userId), newScore);
 
-        userRepository.findById(userId).ifPresent(u -> {
-            if (u.getSchool() != null) {
-                long sid = u.getSchool().getSchoolId();
-                z.add(schoolKey(sid), memberUser(userId), newScore);
-                double delta = newScore - oldScore;
-                if (delta != 0) {
-                    z.incrementScore(SCHOOLS_KEY, memberSchool(sid), delta);
+            userRepository.findById(userId).ifPresentOrElse(u -> {
+                if (u.getSchool() != null) {
+                    long sid = u.getSchool().getSchoolId();
+                    z.add(schoolKey(sid), memberUser(userId), newScore);
+                    double delta = newScore - oldScore;
+                    if (delta != 0) {
+                        z.incrementScore(SCHOOLS_KEY, memberSchool(sid), delta);
+                    }
                 }
-            }
-        });
+            }, () -> {
+                throw new GoGildongException(ExceptionCode.USER_NOT_FOUND);
+            });
+        } catch (DataAccessException e) {
+            throw new GoGildongException(ExceptionCode.REDIS_OPERATION_FAILED);
+        }
     }
 
     // 사용자 학교 변경 시 호출: 이전/새 학교 키에서 이동 처리
     @Transactional
     public void onUserSchoolChanged(long userId, Long oldSchoolId, Long newSchoolId) {
-        var z = redis.opsForZSet();
-        Double sObj = z.score(GLOBAL_KEY, memberUser(userId));
-        double s = sObj == null ? 0d : sObj;
+        try {
+            var z = redis.opsForZSet();
+            Double sObj = z.score(GLOBAL_KEY, memberUser(userId));
+            double s = sObj == null ? 0d : sObj;
 
-        if (oldSchoolId != null) {
-            z.remove(schoolKey(oldSchoolId), memberUser(userId));
-            z.incrementScore(SCHOOLS_KEY, memberSchool(oldSchoolId), -s);
-        }
-        if (newSchoolId != null) {
-            z.add(schoolKey(newSchoolId), memberUser(userId), s);
-            z.incrementScore(SCHOOLS_KEY, memberSchool(newSchoolId), s);
+            if (oldSchoolId != null) {
+                z.remove(schoolKey(oldSchoolId), memberUser(userId));
+                z.incrementScore(SCHOOLS_KEY, memberSchool(oldSchoolId), -s);
+            }
+            if (newSchoolId != null) {
+                z.add(schoolKey(newSchoolId), memberUser(userId), s);
+                z.incrementScore(SCHOOLS_KEY, memberSchool(newSchoolId), s);
+            }
+        } catch (DataAccessException e) {
+            throw new GoGildongException(ExceptionCode.REDIS_OPERATION_FAILED);
         }
     }
 
     // GET /rank : 전체 랭킹 조회
     public GlobalRankListResponse getGlobalTop() {
-        ZSetOperations<String, String> z = redis.opsForZSet();
-        Set<ZSetOperations.TypedTuple<String>> rows =
-                z.reverseRangeWithScores(GLOBAL_KEY, 0, TOP_LIMIT - 1);
+        try {
+            ZSetOperations<String, String> z = redis.opsForZSet();
+            Set<ZSetOperations.TypedTuple<String>> rows =
+                    z.reverseRangeWithScores(GLOBAL_KEY, 0, TOP_LIMIT - 1);
 
-        if (rows == null || rows.isEmpty()) {
-            return GlobalRankListResponse.builder().rankings(List.of()).build();
+            if (rows == null || rows.isEmpty()) {
+                throw new GoGildongException(ExceptionCode.RANK_NOT_FOUND);
+            }
+
+            List<Long> userIds = rows.stream()
+                    .map(t -> parseUserId(t.getValue()))
+                    .toList();
+
+            Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
+                    .collect(Collectors.toMap(User::getUserId, u -> u));
+
+            List<GlobalRankItemDto> items = new ArrayList<>(rows.size());
+            int i = 0;
+            for (ZSetOperations.TypedTuple<String> t : rows) {
+                long uid = parseUserId(t.getValue());
+                long score = t.getScore() == null ? 0L : t.getScore().longValue();
+                User u = userMap.get(uid);
+
+                items.add(GlobalRankItemDto.builder()
+                        .rank(++i)
+                        .user_id(uid)
+                        .user_name(u != null ? u.getUsername() : "(알 수 없음)")
+                        .total_score(score)
+                        .build());
+            }
+
+            return GlobalRankListResponse.builder().rankings(items).build();
+        } catch (DataAccessException e) {
+            throw new GoGildongException(ExceptionCode.REDIS_OPERATION_FAILED);
         }
-
-        List<Long> userIds = rows.stream()
-                .map(t -> parseUserId(t.getValue()))
-                .toList();
-
-        Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
-                .collect(Collectors.toMap(User::getUserId, u -> u));
-
-        List<GlobalRankItemDto> items = new ArrayList<>(rows.size());
-        int i = 0;
-        for (ZSetOperations.TypedTuple<String> t : rows) {
-            long uid = parseUserId(t.getValue());
-            long score = t.getScore() == null ? 0L : t.getScore().longValue();
-            User u = userMap.get(uid);
-
-            items.add(GlobalRankItemDto.builder()
-                    .rank(++i)
-                    .user_id(uid)
-                    .user_name(u != null ? u.getUsername() : null)
-                    .total_score(score)
-                    .build());
-        }
-
-        return GlobalRankListResponse.builder().rankings(items).build();
     }
 
     // GET /rank/mine : 전체 내 랭킹 조회
     public MyGlobalRankResponse getMyGlobalRank(long userId) {
-        ZSetOperations<String, String> z = redis.opsForZSet();
+        User u = userRepository.findById(userId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
 
-        Long zeroBasedRank = z.reverseRank(GLOBAL_KEY, memberUser(userId));
-        Double score = z.score(GLOBAL_KEY, memberUser(userId));
-        Long total = z.zCard(GLOBAL_KEY);
+        try {
+            ZSetOperations<String, String> z = redis.opsForZSet();
 
-        User u = userRepository.findById(userId).orElse(null);
+            Long zeroBasedRank = z.reverseRank(GLOBAL_KEY, memberUser(userId));
+            Double score = z.score(GLOBAL_KEY, memberUser(userId));
+            Long total = z.zCard(GLOBAL_KEY);
 
-        Integer rank1Based = zeroBasedRank == null ? null : (int) (zeroBasedRank + 1);
-        long myScore = score == null ? 0L : score.longValue();
+            Integer rank1Based = zeroBasedRank == null ? null : (int) (zeroBasedRank + 1);
+            long myScore = score == null ? 0L : score.longValue();
 
-        Double percentile = bottomPercentile(rank1Based, total);
+            Double percentile = bottomPercentile(rank1Based, total);
 
-        return MyGlobalRankResponse.builder()
-                .user_id(userId)
-                .user_name(u != null ? u.getUsername() : null)
-                .score(myScore)
-                .global_rank(rank1Based)
-                .global_percentile(percentile)
-                .build();
+            return MyGlobalRankResponse.builder()
+                    .user_id(userId)
+                    .user_name(u.getUsername())
+                    .score(myScore)
+                    .global_rank(rank1Based)
+                    .global_percentile(percentile)
+                    .build();
+        } catch (DataAccessException e) {
+            throw new GoGildongException(ExceptionCode.REDIS_OPERATION_FAILED);
+        }
     }
 
     // GET /rank/school : 교내 전체 랭킹 조회
     public GlobalRankListResponse getSchoolTopByUser(long userId) {
-        User me = userRepository.findById(userId).orElse(null);
-        if (me == null || me.getSchool() == null) {
-            // 소속 학교 없으면 빈 리스트 반환
-            return GlobalRankListResponse.builder().rankings(List.of()).build();
-        }
-        long schoolId = me.getSchool().getSchoolId();
-        String key = schoolKey(schoolId);
-
-        ZSetOperations<String, String> z = redis.opsForZSet();
-        Set<ZSetOperations.TypedTuple<String>> rows =
-                z.reverseRangeWithScores(key, 0, TOP_LIMIT - 1);
-
-        if (rows == null || rows.isEmpty()) {
-            return GlobalRankListResponse.builder().rankings(List.of()).build();
+        User me = userRepository.findById(userId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+        if (me.getSchool() == null) {
+            throw new GoGildongException(ExceptionCode.USER_HAS_NO_SCHOOL);
         }
 
-        List<Long> userIds = rows.stream()
-                .map(t -> parseUserId(t.getValue()))
-                .toList();
+        try {
+            long schoolId = me.getSchool().getSchoolId();
+            String key = schoolKey(schoolId);
 
-        Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
-                .collect(Collectors.toMap(User::getUserId, u -> u));
+            ZSetOperations<String, String> z = redis.opsForZSet();
+            Set<ZSetOperations.TypedTuple<String>> rows =
+                    z.reverseRangeWithScores(key, 0, TOP_LIMIT - 1);
 
-        List<GlobalRankItemDto> items = new ArrayList<>(rows.size());
-        int i = 0;
-        for (ZSetOperations.TypedTuple<String> t : rows) {
-            long uid = parseUserId(t.getValue());
-            long score = t.getScore() == null ? 0L : t.getScore().longValue();
-            User u = userMap.get(uid);
+            if (rows == null || rows.isEmpty()) {
+                throw new GoGildongException(ExceptionCode.RANK_NOT_FOUND);
+            }
 
-            items.add(GlobalRankItemDto.builder()
-                    .rank(++i)
-                    .user_id(uid)
-                    .user_name(u != null ? u.getUsername() : null)
-                    .total_score(score)
-                    .build());
+            List<Long> userIds = rows.stream()
+                    .map(t -> parseUserId(t.getValue()))
+                    .toList();
+
+            Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
+                    .collect(Collectors.toMap(User::getUserId, u -> u));
+
+            List<GlobalRankItemDto> items = new ArrayList<>(rows.size());
+            int i = 0;
+            for (ZSetOperations.TypedTuple<String> t : rows) {
+                long uid = parseUserId(t.getValue());
+                long score = t.getScore() == null ? 0L : t.getScore().longValue();
+                User u = userMap.get(uid);
+
+                items.add(GlobalRankItemDto.builder()
+                        .rank(++i)
+                        .user_id(uid)
+                        .user_name(u != null ? u.getUsername() : "(알 수 없음)")
+                        .total_score(score)
+                        .build());
+            }
+            return GlobalRankListResponse.builder().rankings(items).build();
+        } catch (DataAccessException e) {
+            throw new GoGildongException(ExceptionCode.REDIS_OPERATION_FAILED);
         }
-        return GlobalRankListResponse.builder().rankings(items).build();
     }
 
     // GET /rank/school/mine : 교내 내 랭킹 조회
     public SchoolMyRankResponse getMySchoolRank(long userId) {
-        User me = userRepository.findById(userId).orElse(null);
-        if (me == null || me.getSchool() == null) {
-            return SchoolMyRankResponse.builder()
-                    .user_id(userId)
-                    .user_name(me != null ? me.getUsername() : null)
-                    .score(0)
-                    .my_rank(null)
-                    .my_percentile(null)
-                    .build();
+        User me = userRepository.findById(userId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+        if (me.getSchool() == null) {
+            throw new GoGildongException(ExceptionCode.USER_HAS_NO_SCHOOL);
         }
 
-        long schoolId = me.getSchool().getSchoolId();
-        String key = schoolKey(schoolId);
+        try {
+            long schoolId = me.getSchool().getSchoolId();
+            String key = schoolKey(schoolId);
 
-        ZSetOperations<String, String> z = redis.opsForZSet();
-        Long zeroBasedRank = z.reverseRank(key, memberUser(userId));
-        Double score = z.score(key, memberUser(userId));
-        Long total = z.zCard(key);
+            ZSetOperations<String, String> z = redis.opsForZSet();
+            Long zeroBasedRank = z.reverseRank(key, memberUser(userId));
+            Double score = z.score(key, memberUser(userId));
+            Long total = z.zCard(key);
 
-        Integer rank1Based = zeroBasedRank == null ? null : (int) (zeroBasedRank + 1);
-        long myScore = score == null ? 0L : score.longValue();
+            Integer rank1Based = zeroBasedRank == null ? null : (int) (zeroBasedRank + 1);
+            long myScore = score == null ? 0L : score.longValue();
 
-        Double percentile = bottomPercentile(rank1Based, total);
+            Double percentile = bottomPercentile(rank1Based, total);
 
-        return SchoolMyRankResponse.builder()
-                .user_id(me.getUserId())
-                .user_name(me.getUsername())
-                .score(myScore)
-                .my_rank(rank1Based)
-                .my_percentile(percentile)
-                .build();
+            return SchoolMyRankResponse.builder()
+                    .user_id(me.getUserId())
+                    .user_name(me.getUsername())
+                    .score(myScore)
+                    .my_rank(rank1Based)
+                    .my_percentile(percentile)
+                    .build();
+        } catch (DataAccessException e) {
+            throw new GoGildongException(ExceptionCode.REDIS_OPERATION_FAILED);
+        }
     }
 
     // GET /rank/schools : 전체 학교별 랭킹 조회
     public SchoolRankListResponse getSchoolsBoard() {
-        var z = redis.opsForZSet();
-        var rows = z.reverseRangeWithScores(SCHOOLS_KEY, 0, TOP_LIMIT - 1);
-        if (rows == null || rows.isEmpty()) {
-            return SchoolRankListResponse.builder().rankings(List.of()).build();
+        try {
+            var z = redis.opsForZSet();
+            var rows = z.reverseRangeWithScores(SCHOOLS_KEY, 0, TOP_LIMIT - 1);
+            if (rows == null || rows.isEmpty()) {
+                throw new GoGildongException(ExceptionCode.RANK_NOT_FOUND);
+            }
+
+            List<Long> schoolIds = rows.stream()
+                    .map(t -> Long.parseLong(Objects.requireNonNull(t.getValue()).substring(2)))
+                    .toList();
+
+            Map<Long, School> byId = schoolRepository.findAllById(schoolIds).stream()
+                    .collect(Collectors.toMap(School::getSchoolId, s -> s));
+
+            List<SchoolRankItemDto> items = new ArrayList<>();
+            int i = 0;
+            for (var t : rows) {
+                long sid = Long.parseLong(Objects.requireNonNull(t.getValue()).substring(2));
+                long sum = t.getScore() == null ? 0L : t.getScore().longValue();
+                School s = byId.get(sid);
+
+                items.add(SchoolRankItemDto.builder()
+                        .rank(++i)
+                        .school_id(sid)
+                        .school_name(s != null ? s.getSchoolName() : "(알 수 없음)")
+                        .total_score(sum)
+                        .build());
+            }
+            return SchoolRankListResponse.builder().rankings(items).build();
+        } catch (DataAccessException e) {
+            throw new GoGildongException(ExceptionCode.REDIS_OPERATION_FAILED);
         }
-
-        List<Long> schoolIds = rows.stream()
-                .map(t -> Long.parseLong(Objects.requireNonNull(t.getValue()).substring(2)))
-                .toList();
-
-        Map<Long, School> byId = schoolRepository.findAllById(schoolIds).stream()
-                .collect(Collectors.toMap(School::getSchoolId, s -> s));
-
-        List<SchoolRankItemDto> items = new ArrayList<>();
-        int i = 0;
-        for (var t : rows) {
-            long sid = Long.parseLong(Objects.requireNonNull(t.getValue()).substring(2));
-            long sum = t.getScore() == null ? 0L : t.getScore().longValue();
-            School s = byId.get(sid);
-
-            items.add(SchoolRankItemDto.builder()
-                    .rank(++i)
-                    .school_id(sid)
-                    .school_name(s != null ? s.getSchoolName() : null)
-                    .total_score(sum)
-                    .build());
-        }
-        return SchoolRankListResponse.builder().rankings(items).build();
     }
 
     // GET /rank/schools/mine : 전체 학교 중 내 학교 랭킹 조회
     public MySchoolVsSchoolResponse getMySchoolVsSchoolRank(long userId) {
-        var me = userRepository.findById(userId).orElse(null);
-        if (me == null || me.getSchool() == null) {
-            return MySchoolVsSchoolResponse.builder()
-                    .user_id(userId)
-                    .school_id(null)
-                    .school_name(null)
-                    .score(0)
-                    .school_rank(null)
-                    .school_percentile(null)
-                    .build();
+        User me = userRepository.findById(userId)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));
+        if (me.getSchool() == null) {
+            throw new GoGildongException(ExceptionCode.USER_HAS_NO_SCHOOL);
         }
 
-        long sid = me.getSchool().getSchoolId();
-        var z = redis.opsForZSet();
+        try {
+            long sid = me.getSchool().getSchoolId();
+            var z = redis.opsForZSet();
 
-        Long zeroBased = z.reverseRank(SCHOOLS_KEY, memberSchool(sid));
-        Double score = z.score(SCHOOLS_KEY, memberSchool(sid));
-        Long total = z.zCard(SCHOOLS_KEY);
+            Long zeroBased = z.reverseRank(SCHOOLS_KEY, memberSchool(sid));
+            Double score = z.score(SCHOOLS_KEY, memberSchool(sid));
+            Long total = z.zCard(SCHOOLS_KEY);
 
-        Integer rank1 = zeroBased == null ? null : (int)(zeroBased + 1);
-        long schoolTotal = score == null ? 0L : score.longValue();
+            Integer rank1 = zeroBased == null ? null : (int)(zeroBased + 1);
+            long schoolTotal = score == null ? 0L : score.longValue();
 
-        Double pct = bottomPercentile(rank1, total);
+            Double pct = bottomPercentile(rank1, total);
 
-        return MySchoolVsSchoolResponse.builder()
-                .user_id(userId)
-                .school_id(sid)
-                .school_name(me.getSchool().getSchoolName())
-                .score(schoolTotal)              // 우리 학교 총합 점수
-                .school_rank(rank1)
-                .school_percentile(pct)
-                .build();
+            return MySchoolVsSchoolResponse.builder()
+                    .user_id(userId)
+                    .school_id(sid)
+                    .school_name(me.getSchool().getSchoolName())
+                    .score(schoolTotal)              // 우리 학교 총합 점수
+                    .school_rank(rank1)
+                    .school_percentile(pct)
+                    .build();
+        } catch (DataAccessException e) {
+            throw new GoGildongException(ExceptionCode.REDIS_OPERATION_FAILED);
+        }
     }
 
     // Util method


### PR DESCRIPTION
## 연관 이슈

close #25 

<br/>

## 개요

quiz 및 point 관련 api 구현

<br/>

## 📌 구현 기능

- [x] 전체 퀴즈 목록 조회 GET /quiz
- [x] 퀴즈 단일 조회 GET /quiz/{quiz_id}
- [x] 퀴즈 제출 및 채점 POST /quiz/{quiz_id}
- [x] (개발용) 포인트 증가 POST /point/add
- [x] (개발용) 포인트 감소 POST /point/deduct
- [x] (개발용) 사용자 포인트 조회 GET /point


<br/>
  
## ⚠️ 참고 사항 및 주의할 점
- quiz api 중 퀴즈 응시 시작, 중간저장 api는 삭제하였습니다.
- quiz api중 퀴즈 제출과 결과조회 api를 통합하였습니다.
- `int totalAfterAdd = pointService.addPoints(userId, 50);` : 포인트 추가
- `int totalAfterDeduct = pointService.deductPoints(userId, 30);` : 포인트 감소
- 포인트 수정 시 Redis에 바로 적용됩니다!

<br/>

