### PR TITLE
feat(#66): 엘리베이터 제보 api

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/facility/domain/Elevator.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/domain/Elevator.java
@@ -1,0 +1,69 @@
+package com.efub.gogildong.facility.domain;
+
+import com.efub.gogildong.reports.domain.ElevatorReport;
+import com.efub.gogildong.reports.dto.response.ElevatorAggregateStat;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Elevator {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long elevatorId;
+
+    @Column(nullable = false)
+    private Float doorWidth;
+
+    @Column(nullable = false)
+    private Float minDoorWidth;
+
+    @Column(nullable = false)
+    private Float maxDoorWidth;
+
+    @Column(nullable = false)
+    private Float doorHeight;
+
+    @Column(nullable = false)
+    private Float maxControlPanelHeight;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "facility_id")
+    private Facility facility;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "elevator", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ElevatorReport> elevatorReports = new ArrayList<>();
+
+    @Builder
+    public Elevator(Float doorWidth, Float minDoorWidth, Float maxDoorWidth,
+                    Float doorHeight, Float maxControlPanelHeight, Facility facility) {
+        this.doorWidth = doorWidth;
+        this.minDoorWidth = minDoorWidth;
+        this.maxDoorWidth = maxDoorWidth;
+        this.doorHeight = doorHeight;
+        this.maxControlPanelHeight = maxControlPanelHeight;
+        this.facility = facility;
+    }
+
+    // 엘리베이터 제보 추가
+    public void addElevatorReport(ElevatorReport elevatorReport) {
+        this.elevatorReports.add(elevatorReport);
+        elevatorReport.setElevator(this);
+    }
+
+    // 제보 추가 시 엘리베이터 값 업데이트
+    public void updateAggregate(ElevatorAggregateStat stat) {
+        this.doorWidth = stat.getAvgDoorWidth();
+        this.doorHeight = stat.getAvgDoorHeight();
+        this.maxControlPanelHeight = stat.getAvgMaxControlPanelHeight();
+        this.minDoorWidth = stat.getMinDoorWidth();
+        this.maxDoorWidth = stat.getMaxDoorWidth();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/facility/domain/Facility.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/domain/Facility.java
@@ -2,7 +2,6 @@ package com.efub.gogildong.facility.domain;
 
 import com.efub.gogildong.global.domain.BaseEntity;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -42,6 +41,11 @@ public class Facility extends BaseEntity {
     @OneToOne(mappedBy = "facility", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Setter
     private Restroom restroom;
+
+    // Elevator과 1:1 매핑, 지연로딩 + 고아객체제거
+    @OneToOne(mappedBy = "facility", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Setter
+    private Elevator elevator;
 
     // FacilityReview과 1:n 매핑, 지연로딩 + 고아객체제거
     @OneToMany(mappedBy = "facility", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/gogildong/src/main/java/com/efub/gogildong/reports/controller/ReportController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/controller/ReportController.java
@@ -1,8 +1,6 @@
 package com.efub.gogildong.reports.controller;
 
-import com.efub.gogildong.reports.dto.request.NewRestRoomReportRequest;
-import com.efub.gogildong.reports.dto.request.RestRoomReportRequest;
-import com.efub.gogildong.reports.dto.request.UpdateReportPublicStatusRequest;
+import com.efub.gogildong.reports.dto.request.*;
 import com.efub.gogildong.reports.dto.response.ReportFlagListResponse;
 import com.efub.gogildong.reports.dto.response.ReportListResponse;
 import com.efub.gogildong.reports.dto.response.RestRoomReportResponse;
@@ -39,6 +37,26 @@ public class ReportController {
     public ResponseEntity<Void> createReportAboutExistingRestroom(@RequestBody @Valid RestRoomReportRequest restRoomReportRequest,
                                                                   Authentication authentication) {
         reportService.createReportAboutExistingRestroom(authentication.getName(), restRoomReportRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /*
+     * 새 엘리베이터를 추가하고 해당 엘리베이터에 대해 제보합니다.
+     * */
+    @PostMapping("/elevator/new-facility")
+    public ResponseEntity<Void> createReportAboutNewElevator(@RequestBody @Valid NewElevatorReportRequest newFacilityReportRequest,
+                                                             Authentication authentication) {
+        reportService.createReportAboutNewElevator(authentication.getName(), newFacilityReportRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /*
+     * 기존 엘리베이터에 대해 제보합니다.
+     * */
+    @PostMapping("/elevator")
+    public ResponseEntity<Void> createReportAboutExistingElevator(@RequestBody @Valid ElevatorReportRequest elevatorReportRequest,
+                                                                  Authentication authentication) {
+        reportService.createReportAboutExistingElevator(authentication.getName(), elevatorReportRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/gogildong/src/main/java/com/efub/gogildong/reports/domain/ElevatorReport.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/domain/ElevatorReport.java
@@ -1,0 +1,53 @@
+package com.efub.gogildong.reports.domain;
+
+import com.efub.gogildong.facility.domain.Elevator;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class ElevatorReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long elevatorReportId;
+
+    @Column(nullable = false)
+    private String elevatorReportImage;
+
+    @Column(nullable = false)
+    private Float doorWidth;
+
+    @Column(nullable = false)
+    private Float doorHeight;
+
+    @Column(nullable = false)
+    private Float maxControlPanelHeight;
+
+    private String note;
+
+    @OneToOne
+    @Setter
+    @JoinColumn(name = "report_id", nullable = false)
+    private Report report;
+
+    @ManyToOne
+    @JoinColumn(name = "elevator_id", nullable = false)
+    @Setter
+    private Elevator elevator;
+
+    @Builder
+    public ElevatorReport(String elevatorReportImage, Float doorWidth, Float doorHeight, Float maxControlPanelHeight, String note, Report report, Elevator elevator) {
+        this.elevatorReportImage = elevatorReportImage;
+        this.doorWidth = doorWidth;
+        this.doorHeight = doorHeight;
+        this.maxControlPanelHeight = maxControlPanelHeight;
+        this.note = note;
+        this.report = report;
+        this.elevator = elevator;
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/domain/Report.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/domain/Report.java
@@ -40,11 +40,15 @@ public class Report extends BaseEntity {
     @OneToOne(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private RestRoomReport restRoomReport;
 
+    @OneToOne(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private ElevatorReport elevatorReport;
+
     @Builder
-    public Report(Boolean isPublic, FacilityType reportType, User user) {
+    public Report(Boolean isPublic, FacilityType reportType, User user, Facility facility) {
         this.isPublic = isPublic;
         this.reportType = reportType;
         this.user = user;
+        this.facility = facility;
     }
 
     // 신고 횟수 추가

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/ElevatorReportRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/ElevatorReportRequest.java
@@ -1,0 +1,12 @@
+package com.efub.gogildong.reports.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ElevatorReportRequest extends NewElevatorReportRequest {
+    private Long facilityId;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/NewElevatorReportRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/NewElevatorReportRequest.java
@@ -1,0 +1,66 @@
+package com.efub.gogildong.reports.dto.request;
+
+import com.efub.gogildong.facility.domain.*;
+import com.efub.gogildong.reports.domain.ElevatorReport;
+import com.efub.gogildong.reports.domain.Report;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NewElevatorReportRequest {
+    private Long floorId;
+
+    @NotBlank(message = "시설 이름을 작성해주세요.")
+    private String facilityName;
+
+    @NotBlank(message = "시설 사진을 포함해주세요!")
+    private String elevatorReportImage;
+
+    private Float doorWidth;
+
+    private Float doorHeight;
+
+    private Float maxControlPanelHeight;
+
+    private String note;
+
+    public static Facility toFacilityEntity(NewElevatorReportRequest request, String facilityName, Floor floor) {
+        return Facility.builder()
+                .facilityName(facilityName)
+                .facilityNickname(request.getFacilityName())
+                .facilityType(FacilityType.ELEVATOR)
+                .floor(floor)
+                .build();
+    }
+
+    public static ElevatorReport toElevatorReportEntity(NewElevatorReportRequest request, Report report) {
+        return ElevatorReport.builder()
+                .elevatorReportImage(request.getElevatorReportImage())
+                .doorWidth(request.getDoorWidth())
+                .doorHeight(request.getDoorHeight())
+                .maxControlPanelHeight(request.getMaxControlPanelHeight())
+                .note(request.getNote())
+                .build();
+    }
+
+    public static Elevator toElevatorEntity(NewElevatorReportRequest request, Facility facility, ElevatorReport report) {
+        Elevator elevator = Elevator.builder()
+                .doorHeight(request.getDoorHeight())
+                .doorWidth(request.getDoorWidth())
+                .maxControlPanelHeight(request.getMaxControlPanelHeight())
+                .facility(facility)
+                .maxDoorWidth(request.getDoorWidth())
+                .minDoorWidth(request.getDoorWidth())
+                .build();
+
+        elevator.addElevatorReport(report);
+
+        return elevator;
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/ElevatorAggregateStat.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/ElevatorAggregateStat.java
@@ -1,0 +1,16 @@
+package com.efub.gogildong.reports.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ElevatorAggregateStat {
+    private Float avgDoorWidth;
+    private Float avgDoorHeight;
+    private Float avgMaxControlPanelHeight;
+    private Float minDoorWidth;
+    private Float maxDoorWidth;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/ElevatorReportResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/ElevatorReportResponse.java
@@ -1,0 +1,32 @@
+package com.efub.gogildong.reports.dto.response;
+
+import com.efub.gogildong.reports.domain.ElevatorReport;
+import com.efub.gogildong.user.dto.response.UserResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ElevatorReportResponse {
+    private Long reportId;
+    private Long elevatorReportId;
+    private UserResponseDto user;
+    private String elevatorReportImage;
+    private Float doorWidth;
+    private Float doorHeight;
+    private Float maxControlPanelHeight;
+    private String note;
+
+    public static ElevatorReportResponse from(ElevatorReport elevatorReport) {
+        return ElevatorReportResponse.builder()
+                .reportId(elevatorReport.getReport().getReportId())
+                .elevatorReportId(elevatorReport.getElevatorReportId())
+                .user(UserResponseDto.from(elevatorReport.getReport().getUser()))
+                .elevatorReportImage(elevatorReport.getElevatorReportImage())
+                .doorWidth(elevatorReport.getDoorWidth())
+                .doorHeight(elevatorReport.getDoorHeight())
+                .maxControlPanelHeight(elevatorReport.getMaxControlPanelHeight())
+                .note(elevatorReport.getNote())
+                .build();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/repository/ElevatorReportRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/repository/ElevatorReportRepository.java
@@ -1,0 +1,18 @@
+package com.efub.gogildong.reports.repository;
+
+import com.efub.gogildong.facility.domain.Elevator;
+import com.efub.gogildong.reports.domain.ElevatorReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ElevatorReportRepository extends JpaRepository<ElevatorReport, Long> {
+    @Query("""
+            SELECT r FROM ElevatorReport r 
+            WHERE r.elevator = :elevator 
+              AND r.report.isPublic = true
+           """)
+    List<ElevatorReport> findPublicByElevator(@Param("elevator")Elevator elevator);
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
@@ -7,18 +7,15 @@ import com.efub.gogildong.facility.service.FacilityNameGenerator;
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
 import com.efub.gogildong.global.util.EntityFinder;
+import com.efub.gogildong.reports.domain.ElevatorReport;
 import com.efub.gogildong.reports.domain.Report;
 import com.efub.gogildong.reports.domain.ReportFlag;
 import com.efub.gogildong.reports.domain.RestRoomReport;
-import com.efub.gogildong.reports.dto.request.NewRestRoomReportRequest;
-import com.efub.gogildong.reports.dto.request.RestRoomReportRequest;
-import com.efub.gogildong.reports.dto.request.UpdateReportPublicStatusRequest;
-import com.efub.gogildong.reports.dto.response.ReportFlagListResponse;
-import com.efub.gogildong.reports.dto.response.ReportListResponse;
-import com.efub.gogildong.reports.dto.response.RestRoomAggregateStat;
-import com.efub.gogildong.reports.dto.response.RestRoomReportResponse;
+import com.efub.gogildong.reports.dto.request.*;
+import com.efub.gogildong.reports.dto.response.*;
 import com.efub.gogildong.reports.dto.summary.ReportFlagSummary;
 import com.efub.gogildong.reports.dto.summary.ReportSummary;
+import com.efub.gogildong.reports.repository.ElevatorReportRepository;
 import com.efub.gogildong.reports.repository.ReportFlagRepository;
 import com.efub.gogildong.reports.repository.ReportRepository;
 import com.efub.gogildong.reports.repository.RestRoomReportRepository;
@@ -41,6 +38,7 @@ public class ReportService {
     private final FacilityRepository facilityRepository;
     private final RestroomRespository restroomRespository;
     private final ReportFlagRepository reportFlagRepository;
+    private final ElevatorReportRepository elevatorReportRepository;
 
     /*
     * 시설을 생성하고 해당 시설에 대한 제보를 생성합니다.
@@ -56,7 +54,7 @@ public class ReportService {
 
         // 관련 엔티티 생성
         Facility facility = NewRestRoomReportRequest.toFacilityEntity(request, facilityName, floor);
-        Report report = createReport();
+        Report report = createRestroomReport();
         RestRoomReport restRoomReport = NewRestRoomReportRequest.toRestRoomReportEntity(request, report);
         Restroom newRestroom = NewRestRoomReportRequest.toRestroomEntity(request, facility, restRoomReport);
 
@@ -81,7 +79,7 @@ public class ReportService {
         User user = validateReportWriterByFloorAndGet(loginId, facility.getFloor().getFloorId());
 
         // 관련 엔티티 생성
-        Report report = createReport();
+        Report report = createRestroomReport();
         RestRoomReport restRoomReport = NewRestRoomReportRequest.toRestRoomReportEntity(request, report);
         facility.getRestroom().addRestRoomReport(restRoomReport);
 
@@ -96,13 +94,81 @@ public class ReportService {
     }
 
     /*
-    * 제보를 생성합니다.
+    * 화장실 제보를 생성합니다.
     * */
-    private Report createReport(){
+    private Report createRestroomReport(){
         return Report.builder()
                 .isPublic(true)
                 .reportType(FacilityType.RESTROOM)
                 .build();
+    }
+
+    /*
+     * 엘리베이터를 생성하고 해당 시설에 대한 제보를 생성합니다.
+     * */
+    @Transactional
+    public void createReportAboutNewElevator(String loginId, NewElevatorReportRequest request){
+        // 작성자 권한 확인
+        User user = validateReportWriterByFloorAndGet(loginId, request.getFloorId());
+        Floor floor = finder.getFloorById(request.getFloorId());
+
+        // 시설 이름 생성
+        String facilityName = generateFacilityName(floor);
+
+        // 관련 엔티티 생성
+        Facility facility = NewElevatorReportRequest.toFacilityEntity(request, facilityName, floor);
+        Facility savedFacility = facilityRepository.save(facility);
+        Report report = Report.builder()
+                .isPublic(true)
+                .reportType(FacilityType.ELEVATOR)
+                .facility(savedFacility)
+                .user(user)
+                .build();
+        Report savedReport = reportRepository.save(report);
+
+
+        ElevatorReport elevatorReport = NewElevatorReportRequest.toElevatorReportEntity(request, report);
+        Elevator newElevator = NewElevatorReportRequest.toElevatorEntity(request, facility, elevatorReport);
+
+        // 연관관계 생성
+        user.addReport(report);
+        elevatorReport.setReport(savedReport);
+        elevatorReport.setElevator(newElevator);
+        facility.setElevator(newElevator);
+
+        // 관련 엔티티 저장
+        reportRepository.save(report);
+        facilityRepository.save(facility);
+    }
+
+    /*
+     * 기존 엘리베이터에 대한 제보를 생성합니다.
+     * */
+    @Transactional
+    public void createReportAboutExistingElevator(String loginId, ElevatorReportRequest request){
+        // 작성자 권한 확인
+        Facility facility = finder.getFacilityById(request.getFacilityId());
+        User user = validateReportWriterByFloorAndGet(loginId, facility.getFloor().getFloorId());
+
+        // 관련 엔티티 생성
+        Report report = Report.builder()
+                .isPublic(true)
+                .reportType(FacilityType.ELEVATOR)
+                .facility(facility)
+                .user(user)
+                .build();
+        ElevatorReport elevatorReport = NewElevatorReportRequest.toElevatorReportEntity(request, report);
+        elevatorReport.setReport(report);
+        facility.getElevator().addElevatorReport(elevatorReport);
+
+        user.addReport(report);
+
+        facility.updateNickname(request.getFacilityName());
+
+        reportRepository.save(report);
+        elevatorReportRepository.save(elevatorReport);
+
+        updateElevatorAggregate(facility.getElevator());
     }
 
     /*
@@ -162,6 +228,31 @@ public class ReportService {
 
         // 4) Restroom update
         restroom.updateAggregate(stat);
+    }
+
+    /*
+     * 최근 데이터를 기반으로 화장실 정보를 재구성합니다.
+     * */
+    private void updateElevatorAggregate(Elevator elevator){
+        List<ElevatorReport> reports = elevatorReportRepository.findPublicByElevator(elevator);
+
+        // 숫자 평균, min, max
+        Float avgDoorWidth = (float) reports.stream().mapToDouble(ElevatorReport::getDoorWidth).average().orElse(elevator.getDoorWidth());
+        Float avgDoorHeight = (float) reports.stream().mapToDouble(ElevatorReport::getDoorHeight).average().orElse(elevator.getDoorHeight());
+        Float avgMaxControlPanelHeight = (float) reports.stream().mapToDouble(ElevatorReport::getMaxControlPanelHeight).average().orElse(elevator.getMaxControlPanelHeight());
+        Float minDoorWidth = (float) reports.stream().mapToDouble(ElevatorReport::getDoorWidth).min().orElse(elevator.getMinDoorWidth());
+        Float maxDoorWidth = (float) reports.stream().mapToDouble(ElevatorReport::getDoorWidth).max().orElse(elevator.getMaxDoorWidth());
+
+        ElevatorAggregateStat stat = ElevatorAggregateStat.builder()
+                .avgDoorWidth(avgDoorWidth)
+                .avgDoorHeight(avgDoorHeight)
+                .avgMaxControlPanelHeight(avgMaxControlPanelHeight)
+                .minDoorWidth(minDoorWidth)
+                .maxDoorWidth(maxDoorWidth)
+                .build();
+
+        // Elevator update
+        elevator.updateAggregate(stat);
     }
 
     /*


### PR DESCRIPTION
## 연관 이슈

close #66

<br/>

## 개요

사용자가 새/기존 엘리베이터에 대한 접근성 정보를 제보합니다.

<br/>

## 📌 구현 기능

- [x] 새 엘리베이터 추가 후 제보 api
  <img width="1814" height="912" alt="image" src="https://github.com/user-attachments/assets/f3f0f211-bd4e-45e5-a1af-2bef00664eab" />

- [x] 기존 엘리베이터에 대한 제보 api
  <img width="1810" height="930" alt="image" src="https://github.com/user-attachments/assets/a174e6d2-186e-4e2f-8f0d-1b8c3be6ec0d" />

<br/>

## ⚠️ 어려웠던 점과 해결 과정
연관된 테이블이 많아서 어려웠습니다. Report가 필수 값으로 요구하는 Facility와 User가 데이터베이스에 저장되거나 연결되기 전에 Report를 먼저 저장하려고 해서 TransientPropertyValueException 발생. -> 엔티티 저장 순서를 의존성 순서에 맞게 변경함.
