### PR TITLE
feature(#56) : 이메일 인증 api  및 관련 에러 핸들링

### DIFF
--- a/gogildong/build.gradle
+++ b/gogildong/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
     // 엑셀파일
     implementation 'org.apache.poi:poi-ooxml:5.2.3'
+
+    // Email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/gogildong/src/main/java/com/efub/gogildong/email/controller/EmailVerificationController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/email/controller/EmailVerificationController.java
@@ -1,0 +1,36 @@
+package com.efub.gogildong.email.controller;
+
+import com.efub.gogildong.email.dto.SendEmailCodeRequest;
+import com.efub.gogildong.email.dto.SimpleMessageResponse;
+import com.efub.gogildong.email.dto.VerifyEmailCodeRequest;
+import com.efub.gogildong.email.service.EmailVerificationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth/email")
+public class EmailVerificationController {
+
+    private final EmailVerificationService emailVerificationService;
+
+    /*
+    POST /auth/email/code : 인증번호 발송
+     */
+    @PostMapping("/code")
+    public ResponseEntity<SimpleMessageResponse> sendEmailCode(@RequestBody @Valid SendEmailCodeRequest request) {
+        emailVerificationService.sendCode(request.getEmail());
+        return ResponseEntity.ok(new SimpleMessageResponse("인증번호가 발송되었습니다."));
+    }
+
+    /*
+    POST /auth/email/verify : 인증번호 확인
+     */
+    @PostMapping("/verify")
+    public ResponseEntity<SimpleMessageResponse> verifyEmailCode(@RequestBody @Valid VerifyEmailCodeRequest request) {
+        emailVerificationService.verifyCode(request.getEmail(), request.getVerificationCode());
+        return ResponseEntity.ok(new SimpleMessageResponse("이메일 인증이 완료되었습니다."));
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/email/domain/EmailVerificationCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/email/domain/EmailVerificationCode.java
@@ -1,0 +1,51 @@
+package com.efub.gogildong.email.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import jakarta.persistence.Id;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class EmailVerificationCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false, length = 6)
+    private String code;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private boolean verified = false;
+
+    public void markVerified() {
+        this.verified = true;
+    }
+
+    @Builder
+    public EmailVerificationCode(String email, String code, LocalDateTime expiresAt) {
+        this.email = email;
+        this.code = code;
+        this.expiresAt = expiresAt;
+        this.verified = false;
+    }
+
+
+}
+

--- a/gogildong/src/main/java/com/efub/gogildong/email/dto/SendEmailCodeRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/email/dto/SendEmailCodeRequest.java
@@ -1,0 +1,15 @@
+package com.efub.gogildong.email.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SendEmailCodeRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/email/dto/SimpleMessageResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/email/dto/SimpleMessageResponse.java
@@ -1,0 +1,11 @@
+package com.efub.gogildong.email.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SimpleMessageResponse {
+
+    private String message;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/email/dto/VerifyEmailCodeRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/email/dto/VerifyEmailCodeRequest.java
@@ -1,0 +1,18 @@
+package com.efub.gogildong.email.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VerifyEmailCodeRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String verificationCode;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/email/repository/EmailVerificationCodeRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/email/repository/EmailVerificationCodeRepository.java
@@ -1,0 +1,16 @@
+package com.efub.gogildong.email.repository;
+
+import com.efub.gogildong.email.domain.EmailVerificationCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationCodeRepository extends JpaRepository<EmailVerificationCode, Long> {
+
+    // 가장 최근 코드
+    Optional<EmailVerificationCode> findTopByEmailOrderByIdDesc(String email);
+
+    // 특정 코드
+    Optional<EmailVerificationCode> findByEmailAndCode(String email, String code);
+}
+

--- a/gogildong/src/main/java/com/efub/gogildong/email/service/EmailSender.java
+++ b/gogildong/src/main/java/com/efub/gogildong/email/service/EmailSender.java
@@ -1,0 +1,6 @@
+package com.efub.gogildong.email.service;
+
+public interface EmailSender {
+
+    void send(String to, String subject, String content);
+}

--- a/gogildong/src/main/java/com/efub/gogildong/email/service/EmailVerificationService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/email/service/EmailVerificationService.java
@@ -1,0 +1,80 @@
+package com.efub.gogildong.email.service;
+
+import com.efub.gogildong.email.domain.EmailVerificationCode;
+import com.efub.gogildong.email.repository.EmailVerificationCodeRepository;
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final EmailVerificationCodeRepository codeRepository;
+    private final EmailSender emailSender;
+
+    private String generateCode() {
+        Random random = new Random();
+        int num = random.nextInt(900000) + 100000; // 100000 ~ 999999
+        return String.valueOf(num);
+    }
+
+    // 인증번호 발송
+    @Transactional
+    public void sendCode(String email) {
+        String code = generateCode();
+
+        EmailVerificationCode entity = new EmailVerificationCode();
+        // 필드 세팅 (생성자 대신 setter 안 쓰려면 여기서 직접 세팅 메서드 만들어도 됨)
+        // Lombok @Setter 안 쓴다는 가정으로, 리플렉션 대신 생성자 사용해도 됨.
+        // 간단하게 new 후 리플렉션 대신 아래처럼 엔티티에 전용 생성자 추가해도 됨.
+        // 여기서는 편의상 엔티티에 생성자를 추가했다고 가정할 수도 있음.
+
+        // ⇒ 엔티티에 이런 생성자를 추가하는게 더 깔끔:
+        // public EmailVerificationCode(String email, String code, LocalDateTime expiresAt) { ... }
+
+        entity = new EmailVerificationCode(email, code, LocalDateTime.now().plusMinutes(5));
+
+        codeRepository.save(entity);
+
+        String subject = "[고길동] 이메일 인증번호 안내";
+        String content = "이메일 인증번호는 " + code + " 입니다.\n5분 안에 입력해주세요.";
+
+        emailSender.send(email, subject, content);
+    }
+
+    // 인증번호 확인
+    @Transactional
+    public void verifyCode(String email, String code) {
+        EmailVerificationCode entity = codeRepository.findByEmailAndCode(email, code)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.EMAIL_VERIFICATION_CODE_INVALID));
+
+        if (entity.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new GoGildongException(ExceptionCode.EMAIL_VERIFICATION_CODE_EXPIRED);
+        }
+
+        entity.markVerified();
+    }
+
+    // 인증 완료된 상태인지 확인
+    @Transactional(readOnly = true)
+    public void ensureVerified(String email) {
+        EmailVerificationCode entity = codeRepository.findTopByEmailOrderByIdDesc(email)
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.EMAIL_VERIFICATION_REQUIRED));
+
+        if (entity.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new GoGildongException(ExceptionCode.EMAIL_VERIFICATION_CODE_EXPIRED);
+        }
+
+        if (!entity.isVerified()) {
+            throw new GoGildongException(ExceptionCode.EMAIL_VERIFICATION_REQUIRED);
+        }
+    }
+
+}
+

--- a/gogildong/src/main/java/com/efub/gogildong/email/service/SmtpEmailSender.java
+++ b/gogildong/src/main/java/com/efub/gogildong/email/service/SmtpEmailSender.java
@@ -1,0 +1,35 @@
+package com.efub.gogildong.email.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SmtpEmailSender implements EmailSender {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${mail.from}")
+    private String from;
+
+    @Override
+    public void send(String to, String subject, String content) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setFrom(from);
+            message.setSubject(subject);
+            message.setText(content);
+
+            mailSender.send(message);
+            log.info("Email sent successfully. to={}, subject={}", to, subject);
+        } catch (Exception e) {
+            log.error("Failed to send email. to={}, subject={}", to, subject, e);
+        }
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/global/config/SecurityConfig.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/config/SecurityConfig.java
@@ -108,7 +108,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 
                         .requestMatchers("/error").permitAll()
-                        .requestMatchers("/auth/login", "/auth/refresh", "/users/signup/**").permitAll()
+                        .requestMatchers("/auth/login", "/auth/refresh", "/users/signup/**", "/auth/email/**").permitAll()
                         .requestMatchers("/auth/logout").authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/users/**").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/users/me").authenticated()

--- a/gogildong/src/main/java/com/efub/gogildong/global/exception/ClientExceptionCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/exception/ClientExceptionCode.java
@@ -1,5 +1,7 @@
 package com.efub.gogildong.global.exception;
 
+import org.springframework.http.HttpStatus;
+
 public enum ClientExceptionCode {
     // 전체
     INTERNAL_SERVER_ERROR,
@@ -14,6 +16,13 @@ public enum ClientExceptionCode {
     SCHOOL_VIEW_ALREADY_APPROVED,
     SCHOOL_VIEW_REQUEST_PENDING,
     REQUEST_NOT_FOUND,
+
+    // 이메일 인증
+    EMAIL_FORMAT_INVALID,
+    EMAIL_ALREADY_EXISTS,
+    EMAIL_VERIFICATION_CODE_INVALID,
+    EMAIL_VERIFICATION_CODE_EXPIRED,
+    EMAIL_VERIFICATION_REQUIRED,
 
     // 층
     FLOOR_NOT_FOUND,

--- a/gogildong/src/main/java/com/efub/gogildong/global/exception/ExceptionCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/exception/ExceptionCode.java
@@ -45,6 +45,13 @@ public enum ExceptionCode {
     ACCESS_DENIED(HttpStatus.UNAUTHORIZED, ClientExceptionCode.ACCESS_DENIED, "접근이 허용되지 않습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED,ClientExceptionCode.INVALID_PASSWORD, "비밀번호가 일치하지 않습니다."),
 
+    // 이메일 인증
+    EMAIL_FORMAT_INVALID(HttpStatus.BAD_REQUEST, ClientExceptionCode.EMAIL_FORMAT_INVALID, "이메일 형식이 올바르지 않습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, ClientExceptionCode.EMAIL_ALREADY_EXISTS, "이미 가입된 이메일입니다."),
+    EMAIL_VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, ClientExceptionCode.EMAIL_VERIFICATION_CODE_INVALID, "이메일 인증번호가 올바르지 않습니다."),
+    EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, ClientExceptionCode.EMAIL_VERIFICATION_CODE_EXPIRED, "이메일 인증번호가 만료되었습니다."),
+    EMAIL_VERIFICATION_REQUIRED(HttpStatus.BAD_REQUEST, ClientExceptionCode.EMAIL_VERIFICATION_REQUIRED,  "이메일 인증이 필요합니다."),
+
     // 랭크
     RANK_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.RANK_NOT_FOUND, "랭킹 정보를 찾을 수 없습니다."),
     USER_HAS_NO_SCHOOL(HttpStatus.BAD_REQUEST, ClientExceptionCode.USER_HAS_NO_SCHOOL, "소속된 학교가 없습니다."),

--- a/gogildong/src/main/java/com/efub/gogildong/user/controller/UserController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.efub.gogildong.user.controller;
 
-import com.efub.gogildong.auth.dto.CustomUserDetails;
 import com.efub.gogildong.user.dto.request.*;
 import com.efub.gogildong.user.dto.response.InternalUserResponseDto;
 import com.efub.gogildong.user.dto.response.CreateUserResponseDto;
@@ -11,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.Authentication;
 

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/common/BaseUserRequestDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/common/BaseUserRequestDto.java
@@ -22,4 +22,7 @@ public abstract class BaseUserRequestDto {
 
     @NotBlank
     private String phone;
+
+    @NotBlank
+    private String verificationCode;
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/repository/UserRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/repository/UserRepository.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByUserId(Long userId);
     Optional<User> findByLoginId(String loginId);
-
+    boolean existsByEmail(String email);
 }

--- a/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.efub.gogildong.user.service;
 
+import com.efub.gogildong.email.service.EmailVerificationService;
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
 import com.efub.gogildong.schools.domain.School;
@@ -27,6 +28,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final SchoolRepository schoolRepository;
     private final PasswordEncoder passwordEncoder;
+    private final EmailVerificationService emailVerificationService;
 
     // 내부인 생성
     @Transactional
@@ -34,6 +36,12 @@ public class UserService {
 
         // 이메일 형식 체크
         EmailValidator.validateOrThrow(request.getEmail());
+
+        // 이메일 중복 체크
+        validateEmailNotDuplicate(request.getEmail());
+
+        // 이메일 인증번호 검증
+        emailVerificationService.ensureVerified(request.getEmail());
 
         // schoolCode로 학교 조회
         School school = schoolRepository.findBySchoolCode(request.getSchoolCode())
@@ -72,7 +80,14 @@ public class UserService {
     @Transactional
     public CreateUserResponseDto createExternalUser(CreateExternalUserRequestDto request) {
 
+        // 이메일 형식 체크
         EmailValidator.validateOrThrow(request.getEmail());
+
+        // 이메일 중복 체크
+        validateEmailNotDuplicate(request.getEmail());
+
+        // 이메일 인증번호 검증
+        emailVerificationService.ensureVerified(request.getEmail());
 
         User user = request.toEntity();
         user.setPassword(passwordEncoder.encode(request.getPassword()));
@@ -83,7 +98,14 @@ public class UserService {
     // 학교 관리자 생성
     public InternalUserResponseDto createAdminUser(CreateAdminUserRequestDto request) {
 
+        // 이메일 형식 체크
         EmailValidator.validateOrThrow(request.getEmail());
+
+        // 이메일 중복 체크
+        validateEmailNotDuplicate(request.getEmail());
+
+        // 이메일 인증번호 검증
+        emailVerificationService.ensureVerified(request.getEmail());
 
         School school = schoolRepository.findBySchoolCode(request.getSchoolCode())
                 .orElseThrow(() -> new GoGildongException(ExceptionCode.SCHOOL_NOT_FOUND));
@@ -140,7 +162,13 @@ public class UserService {
         }
     }
 
-    // login id로 유저 반환
+    private void validateEmailNotDuplicate(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new GoGildongException(ExceptionCode.EMAIL_ALREADY_EXISTS);
+        }
+    }
+
+        // login id로 유저 반환
     public User getUserByLoginId(String loginId) {
         return userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new GoGildongException(ExceptionCode.USER_NOT_FOUND));

--- a/gogildong/src/main/resources/application-dev.yml
+++ b/gogildong/src/main/resources/application-dev.yml
@@ -19,9 +19,21 @@ spring:
     redis:
       host: localhost
       port: ${REDIS_PORT:6379}
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: gogildong.power@gmail.com
+    password: ${APP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          connectiontimeout: 5000 # 클라이언트가 SMTP 서버와의 연결을 설정하는 데 대기해야 하는 시간
+          timeout: 5000 # 클라이언트가 SMTP 서버로부터 응답을 대기해야 하는 시간
+          writetimeout: 5000 # 클라이언트가 작업을 완료하는데 대기해야 하는 시간
+    auth-code-expiration-millis: 1800000
 
-logging:
-  level:
-    root: DEBUG
-    org.springframework: DEBUG
-    com.efub.gogildong: DEBUG
+mail:
+  from: gogildong.power@gmail.com


### PR DESCRIPTION
## 연관 이슈

close #56 

<br/>

## 개요

회원가입 시 사용자가 이메일 인증 코드를 받고 입력하여 인증합니다.

<br/>

## 📌 구현 기능

- [x] 인증번호 발송 api
   <img width="1802" height="778" alt="image" src="https://github.com/user-attachments/assets/841cb5c5-908f-4832-9463-f972bc617196" />
  <img width="400" height="360" alt="image" src="https://github.com/user-attachments/assets/f3d56369-08ed-49cf-85af-90892c31a3fe" />

- [x] 인증번호 확인 api
  <img width="1802" height="772" alt="image" src="https://github.com/user-attachments/assets/2556a12b-7337-4c1c-86d9-9a565d098fd8" />

- [x] 이메일 인증 관련 에러 핸들링

<br/>

## ⚠️ 어려웠던 점과 해결 과정
- SecurityFilterChain에 로그인 인증 api 요청 허용 안했더니 401 에러 발생 -> 앞으로 까먹지말고 추가하도록 주의

<br/>
  
## ⚠️ 참고 사항 및 주의할 점
- mail sender는 길동이 공용 계정으로 하였고
- ${APP_PASSWORD} 환경변수 추가해야 합니다.

<br/>

