### PR TITLE
feat(#87): 제보, 신고, 댓글 작성 및 퀴즈 성공 시 포인트와 엽전 지급

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewCommentService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewCommentService.java
@@ -13,6 +13,7 @@ import com.efub.gogildong.global.util.EntityFinder;
 import com.efub.gogildong.point.service.PointService;
 import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.schools.service.SchoolViewRequestService;
+import com.efub.gogildong.shops.service.CoinService;
 import com.efub.gogildong.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,7 @@ public class FacilityReviewCommentService {
     private final PointService pointService;
 
     private static final int REVIEW_COMMENT_POINTS = 5;
+    private final CoinService coinService;
 
     // 시설 리뷰 댓글 조회
     @Transactional(readOnly = true)
@@ -65,6 +67,7 @@ public class FacilityReviewCommentService {
         facilityReviewCommentRepository.save(comment);
 
         pointService.addPoints(user.getUserId(), REVIEW_COMMENT_POINTS);
+        coinService.earnCoin(user, REVIEW_COMMENT_POINTS);
 
         return FacilityReviewCommentResponse.from(comment);
     }

--- a/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewService.java
@@ -14,6 +14,7 @@ import com.efub.gogildong.global.util.EntityFinder;
 import com.efub.gogildong.point.service.PointService;
 import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.schools.service.SchoolViewRequestService;
+import com.efub.gogildong.shops.service.CoinService;
 import com.efub.gogildong.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -36,6 +37,7 @@ public class FacilityReviewService {
     private final PointService pointService;
 
     private static final int REVIEW_POINTS = 5;
+    private final CoinService coinService;
 
     // 시설 리뷰 조회
     @Transactional(readOnly = true)
@@ -71,6 +73,7 @@ public class FacilityReviewService {
         facilityReviewRepository.save(review);
 
         pointService.addPoints(user.getUserId(), REVIEW_POINTS);
+        coinService.earnCoin(user, REVIEW_POINTS);
 
         return FacilityReviewResponse.from(review);
     }

--- a/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityService.java
@@ -18,6 +18,7 @@ import com.efub.gogildong.reports.repository.ReportFlagRepository;
 import com.efub.gogildong.reports.repository.ReportRepository;
 import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.schools.service.SchoolViewRequestService;
+import com.efub.gogildong.shops.service.CoinService;
 import com.efub.gogildong.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,6 +37,7 @@ public class FacilityService {
     private final PointService pointService;
 
     private static final int FLAG_FACILITY_IMG_POINTS = 5;
+    private final CoinService coinService;
 
     // 시설 상세 조회
     @Transactional(readOnly = true)
@@ -101,6 +103,7 @@ public class FacilityService {
         ReportFlag flag = request.toEntity(report, user);
 
         pointService.addPoints(user.getUserId(), FLAG_FACILITY_IMG_POINTS);
+        coinService.earnCoin(user, FLAG_FACILITY_IMG_POINTS);
 
         reportFlagRepository.save(flag);
     }

--- a/gogildong/src/main/java/com/efub/gogildong/quiz/service/QuizCommandService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/quiz/service/QuizCommandService.java
@@ -10,6 +10,7 @@ import com.efub.gogildong.quiz.dto.request.SubmitQuizRequest;
 import com.efub.gogildong.quiz.repository.QuizAttemptRepository;
 import com.efub.gogildong.quiz.repository.QuizChoiceRepository;
 import com.efub.gogildong.quiz.repository.QuizRepository;
+import com.efub.gogildong.shops.service.CoinService;
 import com.efub.gogildong.user.domain.User;
 import com.efub.gogildong.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,8 @@ public class QuizCommandService {
     private final QuizChoiceRepository quizChoiceRepository;
     private final PointService pointService;
 
-    private static final int CORRECT_POINT = 20;
+    private static final int CORRECT_POINT = 3;
+    private final CoinService coinService;
 
     @Transactional
     public Map<String, Object> submit(Long quizId, Long userId, SubmitQuizRequest req) {
@@ -69,6 +71,9 @@ public class QuizCommandService {
         Map<String, Object> resp = new LinkedHashMap<>();
         if (isCorrect) {
             int total = pointService.addPoints(userId, CORRECT_POINT);
+
+            // 퀴즈 정답 제출 시 3 엽전 획득
+            coinService.earnCoin(user, CORRECT_POINT);
             resp.put("isCorrect", true);
             resp.put("point", CORRECT_POINT);
             resp.put("totalPoints", total);

--- a/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
@@ -7,6 +7,7 @@ import com.efub.gogildong.facility.service.FacilityNameGenerator;
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
 import com.efub.gogildong.global.util.EntityFinder;
+import com.efub.gogildong.point.service.PointService;
 import com.efub.gogildong.reports.domain.*;
 import com.efub.gogildong.reports.dto.request.*;
 import com.efub.gogildong.reports.dto.request.classroom.ClassroomReportRequest;
@@ -23,6 +24,7 @@ import com.efub.gogildong.reports.dto.response.restroom.RestRoomReportResponse;
 import com.efub.gogildong.reports.dto.summary.ReportFlagSummary;
 import com.efub.gogildong.reports.dto.summary.ReportSummary;
 import com.efub.gogildong.reports.repository.*;
+import com.efub.gogildong.shops.service.CoinService;
 import com.efub.gogildong.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -40,11 +42,12 @@ public class ReportService {
     private final RestRoomReportRepository restRoomReportRepository;
     private final EntityFinder finder;
     private final FacilityRepository facilityRepository;
-    private final RestroomRespository restroomRespository;
     private final ReportFlagRepository reportFlagRepository;
     private final ElevatorReportRepository elevatorReportRepository;
     private final ClassroomReportRepository classroomReportRepository;
-
+    private final CoinService coinService;
+    private final PointService pointService;
+    private final int REPORT_POINT = 20;
     /*
     * 시설을 생성하고 해당 시설에 대한 제보를 생성합니다.
     * */
@@ -74,6 +77,9 @@ public class ReportService {
         // 관련 엔티티 저장
         reportRepository.save(report);
         facilityRepository.save(facility);
+
+        // 제보 시 포인트와 엽전 획득
+        getPointAndCoinByReport(user);
     }
 
     /*
@@ -98,6 +104,9 @@ public class ReportService {
         restRoomReportRepository.save(restRoomReport);
 
         updateRestroomAggregate(facility.getRestroom());
+
+        // 제보 시 포인트와 엽전 획득
+        getPointAndCoinByReport(user);
     }
 
     /*
@@ -150,6 +159,9 @@ public class ReportService {
         // 관련 엔티티 저장
         reportRepository.save(report);
         facilityRepository.save(facility);
+
+        // 제보 시 포인트와 엽전 획득
+        getPointAndCoinByReport(user);
     }
 
     /*
@@ -181,6 +193,9 @@ public class ReportService {
         elevatorReportRepository.save(elevatorReport);
 
         updateElevatorAggregate(facility.getElevator());
+
+        // 제보 시 포인트와 엽전 획득
+        getPointAndCoinByReport(user);
     }
 
     /*
@@ -219,6 +234,9 @@ public class ReportService {
         // 관련 엔티티 저장
         reportRepository.save(report);
         facilityRepository.save(facility);
+
+        // 제보 시 포인트와 엽전 획득
+        getPointAndCoinByReport(user);
     }
 
     /*
@@ -250,6 +268,9 @@ public class ReportService {
         classroomReportRepository.save(classroomReport);
 
         updateClassroomAggregate(facility.getClassroom());
+
+        // 제보 시 포인트와 엽전 획득
+        getPointAndCoinByReport(user);
     }
 
     /*
@@ -410,5 +431,13 @@ public class ReportService {
                 .collect(Collectors.toList());
 
         return ReportFlagListResponse.of(reportId, flags);
+    }
+
+    /*
+     * 제보 시 20 포인트 지급, 20 엽전 지급
+     * */
+    private void getPointAndCoinByReport(User user) {
+        coinService.earnCoin(user, REPORT_POINT);
+        pointService.addPoints(user.getUserId(), REPORT_POINT);
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
@@ -47,7 +47,7 @@ public class ReportService {
     private final ClassroomReportRepository classroomReportRepository;
     private final CoinService coinService;
     private final PointService pointService;
-    private final int REPORT_POINT = 20;
+    private final static int REPORT_POINT = 20;
     /*
     * 시설을 생성하고 해당 시설에 대한 제보를 생성합니다.
     * */


### PR DESCRIPTION
## 연관 이슈

close #87 

<br/>

## 개요
엽전 기능을 추가함에 따라 엽전이 지급되어야 하는 제보 등록, 시설에 대한 댓글 작성, 퀴즈 성공 시에 엽전을 지급하도록 했습니다.
기존 제보서비스에 포인트를 지급하는 기능이 빠져있어 화장실, 엘리베이터, 교실에 포인트 지급도 추가하였습니다.

<br/>

## 📌 구현 기능

- [X] 제보 등록 시 20 포인트 / 20 엽전 획득
- [X] 퀴즈 정답 제출 시 20 포인트 지급에서 3 포인트 지급으로 변경 및 3 엽전 지급
- [X] 시설 리뷰 작성 시 5 엽전 지급

### 📝 논의사항
너무 짜게 포인트나 엽전을 지급하는 것 같아 길동이 키우기에 흥미가 떨어지지는 않을까 걱정이 됩니다...! 🥲🥲
