### PR TITLE
feat(#90): 학교 열람 요청 ai 검수

### DIFF
--- a/gogildong/build.gradle
+++ b/gogildong/build.gradle
@@ -6,6 +6,7 @@ plugins {
 
 ext {
     queryDslVersion = "5.0.0"
+	springAiVersion = "1.1.0"
 }
 
 group = 'com.efub'
@@ -61,6 +62,9 @@ dependencies {
 
     // Email
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// spring AI
+	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"
@@ -71,6 +75,12 @@ sourceSets {
             srcDirs += [querydslDir]
         }
     }
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.ai:spring-ai-bom:$springAiVersion"
+	}
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/gogildong/src/main/java/com/efub/gogildong/ai/dto/response/AccessDecisionResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/ai/dto/response/AccessDecisionResponse.java
@@ -1,0 +1,13 @@
+package com.efub.gogildong.ai.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccessDecisionResponse {
+    private boolean approved;
+    private String reason;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/ai/service/ReportApprovalService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/ai/service/ReportApprovalService.java
@@ -1,0 +1,74 @@
+package com.efub.gogildong.ai.service;
+
+import com.efub.gogildong.ai.dto.response.AccessDecisionResponse;
+import com.efub.gogildong.schools.dto.request.SchoolViewRequestRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportApprovalService {
+
+    private final OpenAiChatModel openAiChatModel;
+
+    public AccessDecisionResponse decide(SchoolViewRequestRequest request) {
+        ChatClient chatClient = ChatClient.create(openAiChatModel);
+
+        // 메시지
+        SystemMessage systemMessage = new SystemMessage("""
+                너는 학교 접근성 정보 플랫폼에서 학교에 대한 접근성 정보 열람 요청 권한 심사 AI야.
+                
+                [심사 규칙]
+                1. 사용자의 목적이 합리적인 경우만 승인한다.
+                    예: 시험 응시 / 연구 / 장애 학생 도움 등
+                2. 장난 등의 불필요한 이유는 거절한다.
+                3. 공격적/불법적/모욕적 발언 포함 시 거절한다.
+                4. 승인/거절 여부를 반드시 논리적 이유와 함께 제공한다.
+                5. 응답은 **항상 JSON 형식**으로 반환한다.
+                6. JSON 외 다른 문자는 절대 포함하지 않는다.
+                7. 승인/거절 사유는 50자 이내로 작성한다.
+                8. 예시는 아래와 같이 작성:
+                
+                예시 1) 승인
+                {
+                    "approved" : true,
+                    "reason" : "친구가 휠체어 이용 학생이라 이동 경로를 파악하려고 함"
+                }
+                
+                예시 2) 거절
+                {
+                    "approved" : false,
+                    "reason" : "사유가 불명확하고 장난성으로 보임"
+                }
+                
+                응답:
+                {
+                  "approved": <true/false>,
+                  "reason": "<승인/거절 사유>"
+                }
+                """);
+        UserMessage userMessage = new UserMessage("""
+                사용자가 학교에 대한 접근성 정보 열람을 요청했습니다.
+                
+                [요청 정보]
+                - 카테고리: %s
+                - 요청 이유 : %s
+                """.formatted(request.getReasonCategory().name(), request.getRequestReason()));
+        AssistantMessage assistantMessage = new AssistantMessage("");
+
+        // 프롬프트
+        Prompt prompt = new Prompt(List.of(systemMessage, userMessage, assistantMessage));
+
+        return chatClient.prompt(prompt)
+                .call()
+                .entity(AccessDecisionResponse.class);
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/ai/service/ReportApprovalService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/ai/service/ReportApprovalService.java
@@ -1,7 +1,10 @@
 package com.efub.gogildong.ai.service;
 
 import com.efub.gogildong.ai.dto.response.AccessDecisionResponse;
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
 import com.efub.gogildong.schools.dto.request.SchoolViewRequestRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -9,6 +12,7 @@ import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.api.common.OpenAiApiClientErrorException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -20,55 +24,67 @@ public class ReportApprovalService {
     private final OpenAiChatModel openAiChatModel;
 
     public AccessDecisionResponse decide(SchoolViewRequestRequest request) {
-        ChatClient chatClient = ChatClient.create(openAiChatModel);
+        try {
+            ChatClient chatClient = ChatClient.create(openAiChatModel);
 
-        // 메시지
-        SystemMessage systemMessage = new SystemMessage("""
-                너는 학교 접근성 정보 플랫폼에서 학교에 대한 접근성 정보 열람 요청 권한 심사 AI야.
-                
-                [심사 규칙]
-                1. 사용자의 목적이 합리적인 경우만 승인한다.
-                    예: 시험 응시 / 연구 / 장애 학생 도움 등
-                2. 장난 등의 불필요한 이유는 거절한다.
-                3. 공격적/불법적/모욕적 발언 포함 시 거절한다.
-                4. 승인/거절 여부를 반드시 논리적 이유와 함께 제공한다.
-                5. 응답은 **항상 JSON 형식**으로 반환한다.
-                6. JSON 외 다른 문자는 절대 포함하지 않는다.
-                7. 승인/거절 사유는 50자 이내로 작성한다.
-                8. 예시는 아래와 같이 작성:
-                
-                예시 1) 승인
-                {
-                    "approved" : true,
-                    "reason" : "친구가 휠체어 이용 학생이라 이동 경로를 파악하려고 함"
-                }
-                
-                예시 2) 거절
-                {
-                    "approved" : false,
-                    "reason" : "사유가 불명확하고 장난성으로 보임"
-                }
-                
-                응답:
-                {
-                  "approved": <true/false>,
-                  "reason": "<승인/거절 사유>"
-                }
-                """);
-        UserMessage userMessage = new UserMessage("""
-                사용자가 학교에 대한 접근성 정보 열람을 요청했습니다.
-                
-                [요청 정보]
-                - 카테고리: %s
-                - 요청 이유 : %s
-                """.formatted(request.getReasonCategory().name(), request.getRequestReason()));
-        AssistantMessage assistantMessage = new AssistantMessage("");
+            // 메시지
+            SystemMessage systemMessage = new SystemMessage("""
+                    너는 학교 접근성 정보 플랫폼에서 학교에 대한 접근성 정보 열람 요청 권한 심사 AI야.
+                    
+                    [심사 규칙]
+                    1. 사용자의 목적이 합리적인 경우만 승인한다.
+                        예: 시험 응시 / 연구 / 장애 학생 도움 등
+                    2. 장난 등의 불필요한 이유는 거절한다.
+                    3. 공격적/불법적/모욕적 발언 포함 시 거절한다.
+                    4. 승인/거절 여부를 반드시 논리적 이유와 함께 제공한다.
+                    5. 응답은 **항상 JSON 형식**으로 반환한다.
+                    6. JSON 외 다른 문자는 절대 포함하지 않는다.
+                    7. 승인/거절 사유는 50자 이내로 작성한다.
+                    8. 예시는 아래와 같이 작성:
+                    
+                    예시 1) 승인
+                    {
+                        "approved" : true,
+                        "reason" : "친구가 휠체어 이용 학생이라 이동 경로를 파악하려고 함"
+                    }
+                    
+                    예시 2) 거절
+                    {
+                        "approved" : false,
+                        "reason" : "사유가 불명확하고 장난성으로 보임"
+                    }
+                    
+                    응답:
+                    {
+                      "approved": <true/false>,
+                      "reason": "<승인/거절 사유>"
+                    }
+                    """);
+            UserMessage userMessage = new UserMessage("""
+                    사용자가 학교에 대한 접근성 정보 열람을 요청했습니다.
+                    
+                    [요청 정보]
+                    - 카테고리: %s
+                    - 요청 이유 : %s
+                    """.formatted(request.getReasonCategory().name(), request.getRequestReason()));
+            AssistantMessage assistantMessage = new AssistantMessage("");
 
-        // 프롬프트
-        Prompt prompt = new Prompt(List.of(systemMessage, userMessage, assistantMessage));
+            // 프롬프트
+            Prompt prompt = new Prompt(List.of(systemMessage, userMessage, assistantMessage));
 
-        return chatClient.prompt(prompt)
-                .call()
-                .entity(AccessDecisionResponse.class);
+            return chatClient.prompt(prompt)
+                    .call()
+                    .entity(AccessDecisionResponse.class);
+        } catch (OpenAiApiClientErrorException e) {
+            // 모델 호출 실패
+            throw new GoGildongException(ExceptionCode.AI_REQUEST_FAILED);
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof JsonProcessingException) {
+                throw new GoGildongException(ExceptionCode.AI_RESPONSE_PARSE_ERROR);
+            }
+            throw new GoGildongException(ExceptionCode.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            throw new GoGildongException(ExceptionCode.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/global/exception/ClientExceptionCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/exception/ClientExceptionCode.java
@@ -47,6 +47,10 @@ public enum ClientExceptionCode {
     // 허가
     UNAUTHORIZED_SCHOOL_ACCESS,
 
+    //Spring AI
+    AI_REQUEST_FAILED,
+    AI_RESPONSE_PARSE_ERROR,
+
     // 사용자
     USER_NOT_FOUND,
     ACCESS_DENIED,

--- a/gogildong/src/main/java/com/efub/gogildong/global/exception/ExceptionCode.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/exception/ExceptionCode.java
@@ -40,6 +40,11 @@ public enum ExceptionCode {
     // 허가
     UNAUTHORIZED_SCHOOL_ACCESS(HttpStatus.UNAUTHORIZED, ClientExceptionCode.UNAUTHORIZED_SCHOOL_ACCESS, "허가되지 않은 사용자가 학교 정보에 접근했습니다."),
 
+    //Spring AI
+    AI_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, ClientExceptionCode.AI_REQUEST_FAILED, "AI 요청 중 오류가 발생했습니다."),
+    AI_RESPONSE_PARSE_ERROR(HttpStatus.BAD_GATEWAY, ClientExceptionCode.AI_RESPONSE_PARSE_ERROR, "AI 응답이 올바른 JSON 구조가 아니어서 처리할 수 없습니다."),
+
+
     // 사용자
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, ClientExceptionCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."),
     ACCESS_DENIED(HttpStatus.UNAUTHORIZED, ClientExceptionCode.ACCESS_DENIED, "접근이 허용되지 않습니다."),

--- a/gogildong/src/main/java/com/efub/gogildong/schools/dto/request/SchoolViewRequestRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/dto/request/SchoolViewRequestRequest.java
@@ -19,9 +19,9 @@ public class SchoolViewRequestRequest {
     private ReasonCategory reasonCategory;
     private String requestReason;
 
-    public SchoolViewRequest toEntity(School school, User user) {
+    public SchoolViewRequest toEntity(School school, User user, RequestStatus status) {
         return SchoolViewRequest.builder()
-                .status(RequestStatus.PENDING)
+                .status(status)
                 .reasonCategory(this.getReasonCategory())
                 .reason(this.requestReason)
                 .phoneNumber(this.phoneNumber)

--- a/gogildong/src/main/java/com/efub/gogildong/schools/service/SchoolViewRequestService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/service/SchoolViewRequestService.java
@@ -1,5 +1,7 @@
 package com.efub.gogildong.schools.service;
 
+import com.efub.gogildong.ai.dto.response.AccessDecisionResponse;
+import com.efub.gogildong.ai.service.ReportApprovalService;
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
 import com.efub.gogildong.global.util.EntityFinder;
@@ -15,6 +17,7 @@ import com.efub.gogildong.schools.dto.response.SchoolViewRequestSummaryResponse;
 import com.efub.gogildong.schools.repository.SchoolViewRequestRepository;
 import com.efub.gogildong.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,10 +26,12 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SchoolViewRequestService {
 
     private final SchoolViewRequestRepository schoolViewRequestRepository;
     private final EntityFinder finder;
+    private final ReportApprovalService reportApprovalService;
 
     // 학교 정보 열람 신청
     public SchoolViewRequestResponse createSchoolViewRequest(String loginId, SchoolViewRequestRequest request) {
@@ -58,8 +63,16 @@ public class SchoolViewRequestService {
             throw new GoGildongException(ExceptionCode.SCHOOL_VIEW_ALREADY_APPROVED);
         }
 
+        // AI 승인
+        AccessDecisionResponse aiResponse = reportApprovalService.decide(request);
+
+        RequestStatus status = RequestStatus.APPROVED;
+        if (!aiResponse.isApproved()) {
+            status = RequestStatus.REJECTED;
+        }
+
         // 새로운 신청 생성
-        SchoolViewRequest viewRequest = request.toEntity(school, user);
+        SchoolViewRequest viewRequest = request.toEntity(school, user, status);
         schoolViewRequestRepository.save(viewRequest);
         return SchoolViewRequestResponse.from(viewRequest);
     }

--- a/gogildong/src/main/resources/application-dev.yml
+++ b/gogildong/src/main/resources/application-dev.yml
@@ -34,6 +34,10 @@ spring:
           timeout: 5000 # 클라이언트가 SMTP 서버로부터 응답을 대기해야 하는 시간
           writetimeout: 5000 # 클라이언트가 작업을 완료하는데 대기해야 하는 시간
     auth-code-expiration-millis: 1800000
+  ai:
+    openai:
+      api-key: ${OPEN_API_KEY}
+
 item:
   image-base-url: https://mycdn.com/items/
 

--- a/gogildong/src/main/resources/application-prod.yml
+++ b/gogildong/src/main/resources/application-prod.yml
@@ -34,6 +34,10 @@ spring:
           timeout: 5000 # 클라이언트가 SMTP 서버로부터 응답을 대기해야 하는 시간
           writetimeout: 5000 # 클라이언트가 작업을 완료하는데 대기해야 하는 시간
     auth-code-expiration-millis: 1800000
+  ai:
+    openai:
+      api-key: ${OPEN_API_KEY}
+
 item:
   image-base-url: https://mycdn.com/items/
 mail:


### PR DESCRIPTION
## 연관 이슈

close #90 

<br/>

## 개요
학교 접근성 정보 열람 요청에 대해 자동 심사를 수행하는 AI 기반 검수 로직을 도입했습니다.
Spring AI를 활용하여 모델 교체 시 코드 변경 없이 설정만으로 대응할 수 있도록 구성했습니다.

## 📌 구현 기능
- [X] 열람 요청 api에 학교 열람 요청 검수 ai 추가
- 열람 승인 시
<img width="2566" height="1310" alt="열람 성공!!" src="https://github.com/user-attachments/assets/37eeed0d-06c3-404e-b37d-7d677d719654" />

- 열람 미승인 시
<img width="2546" height="1238" alt="열람 실패ㅠㅠ" src="https://github.com/user-attachments/assets/d0a9a5c2-8e34-42c3-8272-ebd53e4c8467" />

### 1. Spring AI 기반 검수 서비스 구현
- `OpenAiChatModel`을 기반으로 `ChatClien`t를 생성하여 모델 호출
- 시스템 메시지 + 사용자 메시지 기반으로 JSON 형태의 승인/거절 결과를 생성
- 응답은 AccessDecisionResponse DTO로 자동 매핑 (`entity()` 활용)

### 2. AI 모델 응답 포맷 강제
- 모델이 항상 아래 형태의 JSON만 반환하도록 규칙 설정
```
{
  "approved": true or false,
  "reason": "50자 이내 사유"
}
```
- JSON 외 다른 문자열이 포함되면 파싱 단계에서 예외 발생 → 별도 에러 코드로 처리

### 3. 예외 처리 구조 개선
Spring AI 내부적으로 JsonProcessingException을 직접 던지지 않고 RuntimeException으로 래핑되어 전달되기 때문에 다음과 같이 처리하였습니다.
- OpenAiApiClientErrorException → 모델 호출 실패
- RuntimeException + 내부 cause가 Jackson 예외 → JSON 파싱 오류
- 그 외 예외 → 내부 서버 오류
이를 통해 모델 오류 / 파싱 오류 / 기타 오류를 명확하게 분리해 예외를 반환합니다.

## ⚠️ 어려웠던 점과 해결 과정
### 문제점
- 초기에 OpenAI API를 WebClient로 직접 호출하여 검수 로직을 구현했으나, 간단한 승인/거절 판단 작업임에도 고가의 OpenAI 모델을 지속적으로 호출하는 것은 비용적으로 비효율적이라고 판단했습니다.
- 특히 WebClient로 직접 API를 연동하면 OpenAI, Claude, Gemini, Llama 등 모델이 달라질 때마다 API 스펙이 달라져 코드 변경이 불가피한 구조였습니다.
- 현재는 마감 일정이 촉박하여 MVP 단계에서 OpenAI 모델을 우선적으로 연결해두었지만, 이후 더 저렴한 모델 또는 로컬 환경(Llama 등)으로 전환할 가능성을 열어두고 싶었습니다.

### 해결
- Spring AI를 도입하여 모델 교체 시 코드 변경 없이 YML 설정만 교체해도 되도록 구조 개선했습니다.
- 메시지 구성, 호출 방식, 응답 매핑(entity()) 모두 추상화되어 있어 유지보수가 간편해졌습니다.
  - 개인적으로 응답 dto 매핑 부분이 깔끔해서 너무 좋았어요!! Spring AI 편함!! 굿😁😁
- Spring AI 관련 자료가 부족해 설정 과정은 어려웠으나, 도입 후 동일한 방식으로 OpenAI → Gemini → Llama 등을 쉽게 교체할 수 있는 유연한 구조가 되었습니다.
  
## ⚠️ 참고 사항 및 주의할 점
- API KEY 관련 환경변수 설정이 필요합니다.
