### PR TITLE
fix(#92): 내부인, 학교 관리자 회원가입 시 응답에 schoolId 추가

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/response/InternalUserResponseDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/response/InternalUserResponseDto.java
@@ -13,6 +13,7 @@ public class InternalUserResponseDto {
 
     private Long userId;
     private UserRole role;
+    private Long schoolId;
     private String schoolCode;
     private String schoolName;
 
@@ -20,6 +21,7 @@ public class InternalUserResponseDto {
         return InternalUserResponseDto.builder()
                 .userId(user.getUserId())
                 .role(user.getRole())
+                .schoolId(school != null ? school.getSchoolId() : null)
                 .schoolCode(school != null ? school.getSchoolCode() : null)
                 .schoolName(school != null ? school.getSchoolName() : null)
                 .build();

--- a/gogildong/src/main/java/com/efub/gogildong/user/dto/response/UserResponseDto.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/dto/response/UserResponseDto.java
@@ -15,6 +15,7 @@ public class UserResponseDto {
     private UserRole role;
     private String email;
     private String phone;
+    private Long schoolId;
     private String schoolCode;
     private String schoolName;
 
@@ -27,6 +28,7 @@ public class UserResponseDto {
                 .role(user.getRole())
                 .email(user.getEmail())
                 .phone(user.getPhone())
+                .schoolId(s != null ? s.getSchoolId() : null)
                 .schoolCode(s != null ? s.getSchoolCode() : null)
                 .schoolName(s != null ? s.getSchoolName() : null)
                 .build();


### PR DESCRIPTION
## 연관 이슈

close #92 

<br/>

## 개요

내부인, 학교 관리자 회원가입 시 응답에 schoolId 추가

<br/>

## 📌 구현 기능

- [x] 내부인, 학교 관리자 회원가입 시 응답에 schoolId 추가
