### PR TITLE
feat(#94): 시설 리뷰 요약 ai

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/ai/dto/response/FacilityReviewSummaryResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/ai/dto/response/FacilityReviewSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.efub.gogildong.ai.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FacilityReviewSummaryResponse {
+    private String summary;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/ai/service/FacilityReviewSummaryService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/ai/service/FacilityReviewSummaryService.java
@@ -3,10 +3,12 @@ package com.efub.gogildong.ai.service;
 import com.efub.gogildong.ai.dto.response.FacilityReviewSummaryResponse;
 import com.efub.gogildong.facility.domain.Facility;
 import com.efub.gogildong.facility.domain.FacilityReview;
+import com.efub.gogildong.facility.respository.FacilityRepository;
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -21,16 +23,17 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FacilityReviewSummaryService {
     private final OpenAiChatModel openAiChatModel;
+    private final FacilityRepository facilityRepository;
 
     /*
     * 시설 AI 요약 - 비동기
     * */
     @Async
-    @Transactional
     public void summarizeFacilityReview(Facility facility) {
         List<FacilityReview> reviews = facility.getReviews();
         // 리뷰가 세개 이하면 ai 요약 X
@@ -91,7 +94,7 @@ public class FacilityReviewSummaryService {
 
         // 시설 리뷰 업데이트
         facility.updateSummary(response.getSummary());
-
+        facilityRepository.save(facility);
         } catch (OpenAiApiClientErrorException e) {
             // 모델 호출 실패
             throw new GoGildongException(ExceptionCode.AI_REQUEST_FAILED);

--- a/gogildong/src/main/java/com/efub/gogildong/ai/service/FacilityReviewSummaryService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/ai/service/FacilityReviewSummaryService.java
@@ -1,0 +1,107 @@
+package com.efub.gogildong.ai.service;
+
+import com.efub.gogildong.ai.dto.response.FacilityReviewSummaryResponse;
+import com.efub.gogildong.facility.domain.Facility;
+import com.efub.gogildong.facility.domain.FacilityReview;
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.api.common.OpenAiApiClientErrorException;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FacilityReviewSummaryService {
+    private final OpenAiChatModel openAiChatModel;
+
+    /*
+    * 시설 AI 요약 - 비동기
+    * */
+    @Async
+    @Transactional
+    public void summarizeFacilityReview(Facility facility) {
+        List<FacilityReview> reviews = facility.getReviews();
+        // 리뷰가 세개 이하면 ai 요약 X
+        if(reviews.size() <= 3) {
+            return;
+        }
+
+       String facilityType = facility.getFacilityType().name();
+
+        // - (좋아요 n) 리뷰 내용
+        String reviewListText = facility.getReviews().stream()
+                .map(review -> "- (좋아요 " + review.getLikeCount() + ") " + review.getReviewText())
+                .collect(Collectors.joining("\n"));
+        try {
+        ChatClient chatClient = ChatClient.create(openAiChatModel);
+
+        SystemMessage systemMessage = new SystemMessage("""
+                            당신은 이동약자를 위한 접근성 평가 전문가입니다.
+                            아래 "시설 유형"과 "리뷰 목록"을 기반으로, 이동약자에게 중요한 관점으로 리뷰를 2~3줄로 요약하세요.
+                
+                            ## 요약 지침
+                            - 불필요한 감상/의견은 배제하고 객관적 사실 중심으로 작성
+                            - 부드러운 어조로 끝맺음
+                            - 공격적/불법적/모욕적 발언 포함 리뷰 배제
+                            - 시설 유형에 따라 다음 기준을 우선적으로 반영:
+                              - 화장실: 문 폭, 손잡이, 좌변기 사용 편의성, 바닥 미끄러움, 접근 경로
+                              - 엘리베이터: 이동약자 우선 사용 여부, 작동 여부, 내부 공간, 버튼 높이, 도어 속도, 접근 경로
+                              - 교실/강의실: 출입로 폭, 경사, 접근성 방해 요소
+                              - 그 외 시설: 이동약자가 이용할 때 영향을 주는 물리적 요소 중심으로
+                            - 리뷰의 공통 패턴을 중심으로 핵심만 정리
+                            - 100자 이내로 요약
+                
+                            ## 출력 형식
+                            아래 JSON 형식으로만 응답:
+                            {
+                                "summary": ""
+                            }
+                
+                """);
+
+        UserMessage userMessage = new UserMessage("""
+                    사용자가 다음 시설에 관한 리뷰 요약을 요청했습니다.
+                    
+                    [시설 유형]
+                    %s
+                    
+                    [리뷰 목록]
+                    %s
+                    """.formatted(facilityType, reviewListText));
+
+        AssistantMessage assistantMessage = new AssistantMessage("");
+
+        Prompt prompt = new Prompt(List.of(systemMessage, userMessage, assistantMessage));
+
+        FacilityReviewSummaryResponse response = chatClient.prompt(prompt)
+                .call()
+                .entity(FacilityReviewSummaryResponse.class);
+
+        // 시설 리뷰 업데이트
+        facility.updateSummary(response.getSummary());
+
+        } catch (OpenAiApiClientErrorException e) {
+            // 모델 호출 실패
+            throw new GoGildongException(ExceptionCode.AI_REQUEST_FAILED);
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof JsonProcessingException) {
+                throw new GoGildongException(ExceptionCode.AI_RESPONSE_PARSE_ERROR);
+            }
+            throw new GoGildongException(ExceptionCode.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            throw new GoGildongException(ExceptionCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/facility/domain/Facility.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/domain/Facility.java
@@ -70,4 +70,7 @@ public class Facility extends BaseEntity {
     public void updateNickname(String facilityName) {
         this.facilityNickname = facilityNickname;
     }
+
+    // 시설 리뷰 바탕 요약 업데이트
+    public void updateSummary(String reviewSummary) { this.reviewSummary = reviewSummary; }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewService.java
@@ -1,5 +1,6 @@
 package com.efub.gogildong.facility.service;
 
+import com.efub.gogildong.ai.service.FacilityReviewSummaryService;
 import com.efub.gogildong.facility.domain.Facility;
 import com.efub.gogildong.facility.domain.FacilityReview;
 import com.efub.gogildong.facility.dto.request.FacilityReviewRequest;
@@ -23,9 +24,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +37,7 @@ public class FacilityReviewService {
 
     private static final int REVIEW_POINTS = 5;
     private final CoinService coinService;
+    private final FacilityReviewSummaryService facilityReviewSummaryService;
 
     // 시설 리뷰 조회
     @Transactional(readOnly = true)
@@ -71,6 +71,8 @@ public class FacilityReviewService {
 
         FacilityReview review = request.toEntity(facility, user);
         facilityReviewRepository.save(review);
+
+        facilityReviewSummaryService.summarizeFacilityReview(facility);
 
         pointService.addPoints(user.getUserId(), REVIEW_POINTS);
         coinService.earnCoin(user, REVIEW_POINTS);

--- a/gogildong/src/main/java/com/efub/gogildong/global/config/AsyncConfig.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.efub.gogildong.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}


### PR DESCRIPTION
## 연관 이슈

close #94 

<br/>

## 개요
- 시설 리뷰가 작성되거나 댓글이 추가될 때, 해당 시설의 모든 리뷰를 기반으로 AI 요약을 자동 생성하는 기능을 비동기(Async) 방식으로 도입했습니다.
- 리뷰가 3개 이상일 때만 OpenAI 모델을 호출하며, 이동약자 관점의 접근성 정보를 중심으로 요약하도록 프롬프트를 구성했습니다.

<br/>

## 📌 구현 기능

- [X] `@Async` 기반 비동기 처리로 리뷰 작성 흐름과 분리
- [X] 시설 유형 + (좋아요 수 + 리뷰 내용)을 활용한 AI 요약 프롬프팅 작성

**리뷰 데이터**
<img width="1902" height="392" alt="image" src="https://github.com/user-attachments/assets/e3783bcc-4581-4e8c-82b2-1189e0ba345b" />

**요약 내용**
<img width="1906" height="264" alt="image" src="https://github.com/user-attachments/assets/25db9ceb-5cdb-4245-90ec-b80b5d50a555" />

## ⚠️ 어려웠던 점과 해결 과정
### 문제점
비동기 메서드(`@Async`) 내부에서 `@Transactional`을 함께 사용하면서,
트랜잭션이 예상대로 동작하지 않아 엔티티 변경사항이 DB에 반영되지 않는 문제가 발생했습니다.
예시) 
```
@Async
@Transactional
public void method1(){
  // 생략
  aEntity.updateAttr(attr);
}
```

### 원인
- `@Async`가 적용된 메서드는 별도의 스레드에서 실행됩니다.
- Spring의 `@Transactional`은 프록시 기반 AOP 방식으로 동작하는데, 비동기 스레드에서는 기존 트랜잭션 컨텍스트가 전파되지 않습니다.
- 따라서 변경사항이 DB에 반영되지 않습니다.

### 해결
- 비동기로 실행되는 로직에서는 `@Transactional`을 제거
- 변경된 엔티티는 명시적으로 `repository.save()`를 호출하여 영속화하도록 수정

## ⚠️ 참고 사항 및 주의할 점
- 비동기 스레드 풀을 명시적으로 설정하지 않은 경우 싱글 스레드로 동작하므로 향후 요청량이 많아지면 Executor 설정이 필요할 수 있음.
- 리뷰가 많아질 경우 토큰 수 증가 → 모델 호출 비용 증가 가능성 있음.

### 📝 논의사항

