### PR TITLE
feat(#98): CORS 설정에 프론트 배포 주소 추가

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/global/config/SecurityConfig.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/config/SecurityConfig.java
@@ -73,7 +73,8 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowedOrigins(List.of(
-                "http://localhost:5173"       // 로컬 개발용
+                "http://localhost:5173",       // 로컬 개발용
+                "https://gogildong.vercel.app"      // 배포 프론트
         ));
 
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));


### PR DESCRIPTION
## 연관 이슈

close #98

<br/>

## 개요

 CORS 설정에 프론트 배포 주소 추가

<br/>

## 📌 구현 기능

- [x] CORS 설정에 프론트 배포 주소 추가


