### PR TITLE
fix(#107): 회원가입 성공 시 Redis 사용자 캐시 재구축

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.efub.gogildong.email.service.EmailVerificationService;
 import com.efub.gogildong.global.exception.BusinessValidationException;
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
+import com.efub.gogildong.rank.service.RankService;
 import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.schools.repository.SchoolRepository;
 import com.efub.gogildong.shops.service.UserItemService;
@@ -36,6 +37,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final UserItemService userItemService;
     private final EmailVerificationService emailVerificationService;
+    private final RankService rankService;
 
     /* ====================== 회원가입 ====================== */
 
@@ -59,7 +61,9 @@ public class UserService {
         User savedUser = userRepository.save(user);
         userItemService.wearDefaultItemsForUser(savedUser);
 
+        rankService.upsertUserScore(savedUser.getUserId(), 0L);
         return InternalUserResponseDto.from(savedUser);
+
     }
 
     // 외부인 생성
@@ -82,6 +86,7 @@ public class UserService {
         User savedUser = userRepository.save(user);
         userItemService.wearDefaultItemsForUser(savedUser);
 
+        rankService.upsertUserScore(savedUser.getUserId(), 0L);
         return CreateUserResponseDto.from(savedUser);
     }
 
@@ -109,6 +114,7 @@ public class UserService {
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.changeSchool(school);
 
+        rankService.upsertUserScore(user.getUserId(), 0L);
         return InternalUserResponseDto.from(userRepository.save(user));
     }
 


### PR DESCRIPTION
## 연관 이슈

close #107 

<br/>

## 개요

신규 사용자 가입 완료 후, 해당 사용자의 초기 점수(0L)를 Redis에 즉시 등록하도록 구현했습니다.

<br/>

## 📌 구현 기능

- [x] 회원가입 메서드 내에 RankService.upsertUserScore() 호출 로직을 추가



