### PR TITLE
feat(#110): 기타 시설에 대한 접근성 정보 제보 api

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/facility/domain/Etc.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/domain/Etc.java
@@ -1,0 +1,43 @@
+package com.efub.gogildong.facility.domain;
+
+import com.efub.gogildong.reports.domain.EtcReport;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Etc {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long etcId;
+
+    @Column(nullable = false)
+    private String note;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "facility_id")
+    private Facility facility;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "etc", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<EtcReport> etcReports = new ArrayList<>();
+
+    @Builder
+    public Etc(String note, Facility facility) {
+        this.note = note;
+        this.facility = facility;
+    }
+
+    // 기타 제보 추가
+    public void addEtcReport(EtcReport etcReport) {
+        this.etcReports.add(etcReport);
+        etcReport.setEtc(this);
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/facility/domain/Facility.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/domain/Facility.java
@@ -52,6 +52,11 @@ public class Facility extends BaseEntity {
     @Setter
     private Classroom classroom;
 
+    // etc와 1:1 매핑, 지연로딩 + 고아객체제거
+    @OneToOne(mappedBy = "facility", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Setter
+    private Etc etc;
+
     // FacilityReview과 1:n 매핑, 지연로딩 + 고아객체제거
     @OneToMany(mappedBy = "facility", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<FacilityReview> reviews = new ArrayList<>();

--- a/gogildong/src/main/java/com/efub/gogildong/facility/respository/FloorRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/respository/FloorRepository.java
@@ -11,4 +11,5 @@ public interface FloorRepository extends JpaRepository<Floor, Long> {
     List<Floor> findByBuilding(Building building);
 
     Optional<Floor> findByFloorId(Long floorId);
+    Optional<Floor> findByBuildingAndFloorName(Building building, String floorName);
 }

--- a/gogildong/src/main/java/com/efub/gogildong/reports/controller/ReportController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/controller/ReportController.java
@@ -5,6 +5,7 @@ import com.efub.gogildong.reports.dto.request.classroom.ClassroomReportRequest;
 import com.efub.gogildong.reports.dto.request.classroom.NewClassroomReportRequest;
 import com.efub.gogildong.reports.dto.request.elevator.ElevatorReportRequest;
 import com.efub.gogildong.reports.dto.request.elevator.NewElevatorReportRequest;
+import com.efub.gogildong.reports.dto.request.etc.NewEtcReportRequest;
 import com.efub.gogildong.reports.dto.request.restroom.NewRestRoomReportRequest;
 import com.efub.gogildong.reports.dto.request.restroom.RestRoomReportRequest;
 import com.efub.gogildong.reports.dto.response.ReportFlagListResponse;
@@ -83,6 +84,16 @@ public class ReportController {
     public ResponseEntity<Void> createReportAboutExistingClassroom(@RequestBody @Valid ClassroomReportRequest classroomReportRequest,
                                                                   Authentication authentication) {
         reportService.createReportAboutExistingClassroom(authentication.getName(), classroomReportRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /*
+     * 새 기타 장소을 추가하고 해당 장소에 대해 제보합니다.
+     * */
+    @PostMapping("/etc/new-facility")
+    public ResponseEntity<Void> createReportAboutNewEtc(@RequestBody @Valid NewEtcReportRequest newFacilityReportRequest,
+                                                             Authentication authentication) {
+        reportService.createReportAboutNewEtc(authentication.getName(), newFacilityReportRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/gogildong/src/main/java/com/efub/gogildong/reports/domain/EtcReport.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/domain/EtcReport.java
@@ -1,0 +1,42 @@
+package com.efub.gogildong.reports.domain;
+
+import com.efub.gogildong.facility.domain.Etc;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class EtcReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long etcReportId;
+
+    @Column(nullable = false)
+    private String etcReportImage;
+
+    @Column(nullable = false)
+    private String note;
+
+    @OneToOne
+    @Setter
+    @JoinColumn(name = "report_id", nullable = false)
+    private Report report;
+
+    @ManyToOne
+    @JoinColumn(name = "etc_id", nullable = false)
+    @Setter
+    private Etc etc;
+
+    @Builder
+    public EtcReport(String etcReportImage, String note, Report report, Etc etc) {
+        this.etcReportImage = etcReportImage;
+        this.note = note;
+        this.report = report;
+        this.etc = etc;
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/domain/Report.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/domain/Report.java
@@ -3,7 +3,6 @@ package com.efub.gogildong.reports.domain;
 import com.efub.gogildong.facility.domain.Facility;
 import com.efub.gogildong.facility.domain.FacilityType;
 import com.efub.gogildong.global.domain.BaseEntity;
-import com.efub.gogildong.schools.domain.RequestStatus;
 import com.efub.gogildong.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -50,6 +49,9 @@ public class Report extends BaseEntity {
 
     @OneToOne(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private ClassroomReport classroomReport;
+
+    @OneToOne(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private EtcReport etcReport;
 
     @Builder
     public Report(Boolean isPublic, FacilityType reportType, ReportStatus status, User user, Facility facility) {

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/etc/NewEtcReportRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/etc/NewEtcReportRequest.java
@@ -1,0 +1,54 @@
+package com.efub.gogildong.reports.dto.request.etc;
+
+import com.efub.gogildong.facility.domain.*;
+import com.efub.gogildong.reports.domain.EtcReport;
+import com.efub.gogildong.reports.domain.Report;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NewEtcReportRequest {
+    private Long floorId;
+
+    @NotBlank(message = "시설 이름을 작성해주세요.")
+    private String facilityName;
+
+    @NotBlank(message = "시설 사진을 포함해주세요!")
+    private String etcReportImage;
+
+    @NotBlank(message = "제보에 대해 설명해주세요.")
+    private String note;
+
+    public static Facility toFacilityEntity(NewEtcReportRequest request, String facilityName, Floor floor) {
+        return Facility.builder()
+                .facilityName(facilityName)
+                .facilityNickname(request.getFacilityName())
+                .facilityType(FacilityType.ETC)
+                .floor(floor)
+                .build();
+    }
+
+    public static EtcReport toEtcReportEntity(NewEtcReportRequest request, Report report) {
+        return EtcReport.builder()
+                .etcReportImage(request.getEtcReportImage())
+                .note(request.getNote())
+                .build();
+    }
+
+    public static Etc toEtcEntity(NewEtcReportRequest request, Facility facility, EtcReport report) {
+        Etc etc = Etc.builder()
+                .note(request.getNote())
+                .facility(facility)
+                .build();
+
+        etc.addEtcReport(report);
+
+        return etc;
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/etc/EtcReportResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/etc/EtcReportResponse.java
@@ -1,0 +1,27 @@
+package com.efub.gogildong.reports.dto.response.etc;
+
+import com.efub.gogildong.reports.domain.EtcReport;
+import com.efub.gogildong.user.dto.response.UserResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EtcReportResponse {
+
+    private Long reportId;
+    private Long etcReportId;
+    private UserResponseDto user;
+    private String etcReportImage;
+    private String note;
+
+    public static EtcReportResponse from(EtcReport etcReport) {
+        return EtcReportResponse.builder()
+                .reportId(etcReport.getReport().getReportId())
+                .etcReportId(etcReport.getEtcReportId())
+                .user(UserResponseDto.from(etcReport.getReport().getUser()))
+                .etcReportImage(etcReport.getEtcReportImage())
+                .note(etcReport.getNote())
+                .build();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/repository/EtcReportRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/repository/EtcReportRepository.java
@@ -1,0 +1,18 @@
+package com.efub.gogildong.reports.repository;
+
+import com.efub.gogildong.facility.domain.Etc;
+import com.efub.gogildong.reports.domain.EtcReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface EtcReportRepository extends JpaRepository<EtcReport, Long> {
+    @Query("""
+            SELECT r FROM EtcReport r 
+            WHERE r.etc = :etc 
+              AND r.report.isPublic = true
+           """)
+    List<EtcReport> findPublicByEtc(@Param("etc") Etc etc);
+}

--- a/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
@@ -2,7 +2,7 @@ package com.efub.gogildong.reports.service;
 
 import com.efub.gogildong.facility.domain.*;
 import com.efub.gogildong.facility.respository.FacilityRepository;
-import com.efub.gogildong.facility.respository.RestroomRespository;
+import com.efub.gogildong.facility.respository.FloorRepository;
 import com.efub.gogildong.facility.service.FacilityNameGenerator;
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
@@ -14,6 +14,7 @@ import com.efub.gogildong.reports.dto.request.classroom.ClassroomReportRequest;
 import com.efub.gogildong.reports.dto.request.classroom.NewClassroomReportRequest;
 import com.efub.gogildong.reports.dto.request.elevator.ElevatorReportRequest;
 import com.efub.gogildong.reports.dto.request.elevator.NewElevatorReportRequest;
+import com.efub.gogildong.reports.dto.request.etc.NewEtcReportRequest;
 import com.efub.gogildong.reports.dto.request.restroom.NewRestRoomReportRequest;
 import com.efub.gogildong.reports.dto.request.restroom.RestRoomReportRequest;
 import com.efub.gogildong.reports.dto.response.*;
@@ -45,6 +46,7 @@ public class ReportService {
     private final ReportFlagRepository reportFlagRepository;
     private final ElevatorReportRepository elevatorReportRepository;
     private final ClassroomReportRepository classroomReportRepository;
+    private final FloorRepository floorRepository;
     private final CoinService coinService;
     private final PointService pointService;
     private final static int REPORT_POINT = 20;
@@ -268,6 +270,51 @@ public class ReportService {
         classroomReportRepository.save(classroomReport);
 
         updateClassroomAggregate(facility.getClassroom());
+
+        // 제보 시 포인트와 엽전 획득
+        getPointAndCoinByReport(user);
+    }
+
+    /*
+    기타에 대한 제보를 생성합니다.
+     */
+    @Transactional
+    public void createReportAboutNewEtc(String loginId, NewEtcReportRequest request){
+        // 작성자 권한 확인
+        User user = validateReportWriterByFloorAndGet(loginId, request.getFloorId());
+        Floor floor = finder.getFloorById(request.getFloorId());
+        // 원래 floorId로 floor를 가져온 뒤, 같은 건물의 0층 Floor을 강제 사용
+        Floor zeroFloor = floorRepository.findByBuildingAndFloorName(floor.getBuilding(), "0")
+                .orElseThrow(() -> new GoGildongException(ExceptionCode.FLOOR_NOT_FOUND));
+
+
+        // 시설 이름 생성
+        String facilityName = generateFacilityName(zeroFloor);
+
+        // 관련 엔티티 생성
+        Facility facility = NewEtcReportRequest.toFacilityEntity(request, facilityName, zeroFloor);
+        Facility savedFacility = facilityRepository.save(facility);
+        Report report = Report.builder()
+                .isPublic(true)
+                .reportType(FacilityType.ETC)
+                .facility(savedFacility)
+                .status(ReportStatus.PENDING)
+                .user(user)
+                .build();
+        Report savedReport = reportRepository.save(report);
+
+        EtcReport etcReport = NewEtcReportRequest.toEtcReportEntity(request, report);
+        Etc newEtc = NewEtcReportRequest.toEtcEntity(request, facility, etcReport);
+
+        // 연관관계 생성
+        user.addReport(report);
+        etcReport.setReport(savedReport);
+        etcReport.setEtc(newEtc);
+        facility.setEtc(newEtc);
+
+        // 관련 엔티티 저장
+        reportRepository.save(report);
+        facilityRepository.save(facility);
 
         // 제보 시 포인트와 엽전 획득
         getPointAndCoinByReport(user);


### PR DESCRIPTION
## 연관 이슈

close #110 

<br/>

## 개요

화장실, 교실, 엘리베이터를 제외한 기타 나머지 시설 및 장소에 대한 접근성 정보를 제보합니다.

<br/>

## 📌 구현 기능

- [x] 기타 시설에 대한 접근성 정보 제보 api
  <img width="1600" height="842" alt="image" src="https://github.com/user-attachments/assets/2d1cb9d4-1485-43e0-bac3-06dd811305b3" />


<br/>

## ⚠️ 어려웠던 점과 해결 과정
기타 제보 - 시설 - 건물층 - 학교 건물 테이블이 연결되어 있는데 기타 시설의 경우 층을 지정할 수가 없어서 어떻게 구현해야하는지 어려웠음.
→ 일단 층은 0으로 하였고 시설 타입은 ETC로 지정해둠.

<br/>
  
## ⚠️ 참고 사항 및 주의할 점
원래대로 층을 통해 작성자가 해당 학교 소속인지 확인하고 반환하는 방법을 사용했고, 원래의 floorId로 floor를 가져온 뒤, 같은 건물의 0층 Floor을 강제로 사용하였습니다.

<br/>
