### PR TITLE
[feat] 학교 설정 api

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/global/util/JwtTokenProvider.java
+++ b/gogildong/src/main/java/com/efub/gogildong/global/util/JwtTokenProvider.java
@@ -1,0 +1,24 @@
+package com.efub.gogildong.global.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    public String getUserRole(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.get("role", String.class);
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/schools/controller/AdminSchoolController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/controller/AdminSchoolController.java
@@ -1,0 +1,41 @@
+package com.efub.gogildong.schools.controller;
+
+import com.efub.gogildong.schools.dto.response.AdminSchoolListResponse;
+import com.efub.gogildong.schools.service.AdminSchoolService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/schools")
+public class AdminSchoolController {
+
+    private final AdminSchoolService adminSchoolService;
+
+    // 등록된 학교 리스트 조회
+    @GetMapping
+    public ResponseEntity<AdminSchoolListResponse> getSchools(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        AdminSchoolListResponse response = adminSchoolService.getSchools(page, size);
+        return ResponseEntity.ok(response);
+    }
+
+    // 학교 검색
+    @GetMapping("/search")
+    public ResponseEntity<AdminSchoolListResponse> searchSchools(
+            @RequestParam(required = false) String region,
+            @RequestParam(required = false) String level,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        AdminSchoolListResponse response = adminSchoolService.searchSchools(region, level, keyword, page, size);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/schools/controller/AdminSchoolController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/controller/AdminSchoolController.java
@@ -1,13 +1,12 @@
 package com.efub.gogildong.schools.controller;
 
+import com.efub.gogildong.schools.dto.request.AdminAddSchoolRequest;
+import com.efub.gogildong.schools.dto.response.AdminAddSchoolResponse;
 import com.efub.gogildong.schools.dto.response.AdminSchoolListResponse;
 import com.efub.gogildong.schools.service.AdminSchoolService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,9 +19,11 @@ public class AdminSchoolController {
     @GetMapping
     public ResponseEntity<AdminSchoolListResponse> getSchools(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestHeader("Authorization") String authorizationHeader
     ) {
-        AdminSchoolListResponse response = adminSchoolService.getSchools(page, size);
+        String token = authorizationHeader.replace("Bearer ", "");
+        AdminSchoolListResponse response = adminSchoolService.getSchools(page, size, token);
         return ResponseEntity.ok(response);
     }
 
@@ -33,9 +34,22 @@ public class AdminSchoolController {
             @RequestParam(required = false) String level,
             @RequestParam(required = false) String keyword,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestHeader("Authorization") String authorizationHeader
     ) {
-        AdminSchoolListResponse response = adminSchoolService.searchSchools(region, level, keyword, page, size);
+        String token = authorizationHeader.replace("Bearer ", "");
+        AdminSchoolListResponse response = adminSchoolService.searchSchools(region, level, keyword, page, size, token);
+        return ResponseEntity.ok(response);
+    }
+
+    // 학교 추가
+    @PostMapping("/add")
+    public ResponseEntity<AdminAddSchoolResponse> addSchool(
+            @RequestBody AdminAddSchoolRequest request,
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        String token = authorizationHeader.replace("Bearer ", "");
+        AdminAddSchoolResponse response = adminSchoolService.addSchool(request, token);
         return ResponseEntity.ok(response);
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/schools/dto/request/AdminAddSchoolRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/dto/request/AdminAddSchoolRequest.java
@@ -1,0 +1,28 @@
+package com.efub.gogildong.schools.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminAddSchoolRequest {
+
+    private String schoolCode;
+    private String schoolName;
+    private String address;
+
+    // GeoJSON 형태
+    private Location location;
+
+    private String eduLevel;
+    private String adminCode;
+    private Boolean hasSpecialClass;
+    private String region;
+
+    @Getter
+    @Setter
+    public static class Location {
+        private String type; // "Point"
+        private double[] coordinates; // [lon, lat]
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/schools/dto/response/AdminAddSchoolResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/dto/response/AdminAddSchoolResponse.java
@@ -1,0 +1,23 @@
+package com.efub.gogildong.schools.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class AdminAddSchoolResponse {
+    private Long schoolId;
+    private String schoolCode;
+    private String schoolName;
+    private String address;
+    private String eduLevel;
+    private String adminCode;
+    private Boolean hasSpecialClass;
+    private String region;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/gogildong/src/main/java/com/efub/gogildong/schools/dto/response/AdminSchoolListResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/dto/response/AdminSchoolListResponse.java
@@ -1,0 +1,30 @@
+package com.efub.gogildong.schools.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class AdminSchoolListResponse {
+
+    private int total;
+    private List<SchoolDto> schools;
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class SchoolDto {
+        private String region;
+        private String eduLevel;
+        private String schoolName;
+        private String schoolCode;
+        private String status;
+        private String adminPhone;
+        private LocalDateTime registeredAt;
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/schools/repository/SchoolRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/repository/SchoolRepository.java
@@ -1,5 +1,6 @@
 package com.efub.gogildong.schools.repository;
 
+import com.efub.gogildong.schools.domain.EduLevel;
 import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.statistics.dto.DailyCountProjection; // 🔥 추가
 import org.springframework.data.domain.Page;
@@ -67,5 +68,17 @@ public interface SchoolRepository extends JpaRepository<School, Long> {
     List<DailyCountProjection> countDailyNewSchools(
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
+    );
+
+    // 학교 검색 + 페이징
+    @Query("SELECT s FROM School s " +
+            "WHERE (:region IS NULL OR s.region = :region) " +
+            "AND (:eduLevel IS NULL OR s.eduLevel = :eduLevel) " +
+            "AND (:keyword IS NULL OR s.schoolName LIKE %:keyword%)")
+    Page<School> searchSchools(
+            @Param("region") String region,
+            @Param("eduLevel") EduLevel eduLevel,
+            @Param("keyword") String keyword,
+            Pageable pageable
     );
 }

--- a/gogildong/src/main/java/com/efub/gogildong/schools/service/AdminSchoolService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/service/AdminSchoolService.java
@@ -1,13 +1,22 @@
 package com.efub.gogildong.schools.service;
 
+import com.efub.gogildong.global.exception.ExceptionCode;
+import com.efub.gogildong.global.exception.GoGildongException;
+import com.efub.gogildong.global.util.JwtTokenProvider;
 import com.efub.gogildong.schools.domain.EduLevel;
 import com.efub.gogildong.schools.domain.School;
+import com.efub.gogildong.schools.dto.request.AdminAddSchoolRequest;
+import com.efub.gogildong.schools.dto.response.AdminAddSchoolResponse;
 import com.efub.gogildong.schools.dto.response.AdminSchoolListResponse;
 import com.efub.gogildong.schools.repository.SchoolRepository;
 import com.efub.gogildong.user.domain.User;
 import com.efub.gogildong.user.domain.UserRole;
 import com.efub.gogildong.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -22,9 +31,21 @@ public class AdminSchoolService {
 
     private final SchoolRepository schoolRepository;
     private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final GeometryFactory geometryFactory = new GeometryFactory();
 
     // 등록된 학교 리스트 조회
-    public AdminSchoolListResponse getSchools(int page, int size) {
+    @Transactional
+    public AdminSchoolListResponse getSchools(int page, int size, String accessToken) {
+
+        // 토큰에서 role 추출
+        String role = jwtTokenProvider.getUserRole(accessToken);
+
+        // ADMIN이 아니면 예외 발생
+        if (!"ADMIN".equals(role)) {
+            throw new GoGildongException(ExceptionCode.ACCESS_DENIED);
+        }
+
         // DB에서 페이징 처리
         Page<School> schoolPage = schoolRepository.findAll(PageRequest.of(page, size));
 
@@ -58,7 +79,16 @@ public class AdminSchoolService {
     }
 
     // 학교 검색
-    public AdminSchoolListResponse searchSchools(String region, String level, String keyword, int page, int size) {
+    @Transactional
+    public AdminSchoolListResponse searchSchools(String region, String level, String keyword, int page, int size, String accessToken) {
+
+        // 토큰에서 role 추출
+        String role = jwtTokenProvider.getUserRole(accessToken);
+
+        // ADMIN이 아니면 예외 발생
+        if (!"ADMIN".equals(role)) {
+            throw new GoGildongException(ExceptionCode.ACCESS_DENIED);
+        }
 
         EduLevel eduLevel = null;
         if (level != null && !level.isBlank() && !level.equalsIgnoreCase("all")) {
@@ -91,5 +121,58 @@ public class AdminSchoolService {
                 }).collect(Collectors.toList());
 
         return new AdminSchoolListResponse((int) schoolPage.getTotalElements(), schoolDtos);
+    }
+
+    // 학교 추가
+    @Transactional
+    public AdminAddSchoolResponse addSchool(AdminAddSchoolRequest request, String accessToken) {
+
+        // 토큰에서 role 추출
+        String role = jwtTokenProvider.getUserRole(accessToken);
+
+        // SUPER_ADMIN이 아니면 예외 발생
+        if (!"SUPER_ADMIN".equals(role)) {
+            throw new GoGildongException(ExceptionCode.ACCESS_DENIED);
+        }
+
+        // eduLevel 문자열 -> Enum
+        EduLevel eduLevel;
+        try {
+            eduLevel = EduLevel.valueOf(request.getEduLevel().toLowerCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("올바르지 않은 eduLevel 값입니다.");
+        }
+
+        // Location -> Point
+        double lon = request.getLocation().getCoordinates()[0];
+        double lat = request.getLocation().getCoordinates()[1];
+        Point location = geometryFactory.createPoint(new Coordinate(lon, lat));
+
+        // School 엔티티 생성
+        School school = School.builder()
+                .schoolCode(request.getSchoolCode())
+                .schoolName(request.getSchoolName())
+                .address(request.getAddress())
+                .location(location)
+                .eduLevel(eduLevel)
+                .adminCode(request.getAdminCode()) // null이면 School.prePersist에서 랜덤 생성
+                .hasSpecialClass(request.getHasSpecialClass())
+                .region(request.getRegion())
+                .build();
+
+        schoolRepository.save(school);
+
+        return new AdminAddSchoolResponse(
+                school.getSchoolId(),
+                school.getSchoolCode(),
+                school.getSchoolName(),
+                school.getAddress(),
+                school.getEduLevel().name(),
+                school.getAdminCode(),
+                school.getHasSpecialClass(),
+                school.getRegion(),
+                school.getCreatedAt(),
+                school.getUpdatedAt()
+        );
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/schools/service/AdminSchoolService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/service/AdminSchoolService.java
@@ -1,0 +1,95 @@
+package com.efub.gogildong.schools.service;
+
+import com.efub.gogildong.schools.domain.EduLevel;
+import com.efub.gogildong.schools.domain.School;
+import com.efub.gogildong.schools.dto.response.AdminSchoolListResponse;
+import com.efub.gogildong.schools.repository.SchoolRepository;
+import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.domain.UserRole;
+import com.efub.gogildong.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AdminSchoolService {
+
+    private final SchoolRepository schoolRepository;
+    private final UserRepository userRepository;
+
+    // 등록된 학교 리스트 조회
+    public AdminSchoolListResponse getSchools(int page, int size) {
+        // DB에서 페이징 처리
+        Page<School> schoolPage = schoolRepository.findAll(PageRequest.of(page, size));
+
+        // DTO 변환
+        List<AdminSchoolListResponse.SchoolDto> schoolDtos = schoolPage.stream()
+                .map(school -> {
+                    // 학교 관리자 조회
+                    Optional<User> admin = userRepository.findBySchoolAndRole(school, UserRole.ADMIN)
+                            .stream()
+                            .findFirst();
+
+                    String adminPhone = admin.map(User::getPhone).orElse("");
+
+                    return new AdminSchoolListResponse.SchoolDto(
+                            school.getRegion(),
+                            school.getEduLevel().name(),
+                            school.getSchoolName(),
+                            school.getSchoolCode(),
+                            "REGISTERED",
+                            adminPhone,
+                            school.getCreatedAt()
+                    );
+                })
+                .collect(Collectors.toList());
+
+        // total: 전체 데이터 개수, schools: 현재 페이지 데이터
+        return new AdminSchoolListResponse(
+                (int) schoolPage.getTotalElements(), // 전체 학교 수
+                schoolDtos
+        );
+    }
+
+    // 학교 검색
+    public AdminSchoolListResponse searchSchools(String region, String level, String keyword, int page, int size) {
+
+        EduLevel eduLevel = null;
+        if (level != null && !level.isBlank() && !level.equalsIgnoreCase("all")) {
+            try {
+                eduLevel = EduLevel.valueOf(level.toLowerCase());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("올바르지 않은 eduLevel 값입니다.");
+            }
+        }
+
+        Page<School> schoolPage = schoolRepository.searchSchools(region, eduLevel, keyword, PageRequest.of(page, size));
+
+        List<AdminSchoolListResponse.SchoolDto> schoolDtos = schoolPage.stream()
+                .map(school -> {
+                    Optional<User> admin = userRepository.findBySchoolAndRole(school, UserRole.ADMIN)
+                            .stream()
+                            .findFirst();
+
+                    String adminPhone = admin.map(User::getPhone).orElse("");
+
+                    return new AdminSchoolListResponse.SchoolDto(
+                            school.getRegion(),
+                            school.getEduLevel().name(),
+                            school.getSchoolName(),
+                            school.getSchoolCode(),
+                            "REGISTERED",
+                            adminPhone,
+                            school.getCreatedAt()
+                    );
+                }).collect(Collectors.toList());
+
+        return new AdminSchoolListResponse((int) schoolPage.getTotalElements(), schoolDtos);
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/schools/service/AdminSchoolService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/service/AdminSchoolService.java
@@ -41,8 +41,8 @@ public class AdminSchoolService {
         // 토큰에서 role 추출
         String role = jwtTokenProvider.getUserRole(accessToken);
 
-        // ADMIN이 아니면 예외 발생
-        if (!"ADMIN".equals(role)) {
+        // ADMIN 또는 SUPER_ADMIN이 아니면 예외 발생
+        if (!"ADMIN".equals(role) && !"SUPER_ADMIN".equals(role)) {
             throw new GoGildongException(ExceptionCode.ACCESS_DENIED);
         }
 
@@ -85,8 +85,8 @@ public class AdminSchoolService {
         // 토큰에서 role 추출
         String role = jwtTokenProvider.getUserRole(accessToken);
 
-        // ADMIN이 아니면 예외 발생
-        if (!"ADMIN".equals(role)) {
+        // ADMIN 또는 SUPER_ADMIN이 아니면 예외 발생
+        if (!"ADMIN".equals(role) && !"SUPER_ADMIN".equals(role)) {
             throw new GoGildongException(ExceptionCode.ACCESS_DENIED);
         }
 

--- a/gogildong/src/main/java/com/efub/gogildong/user/repository/UserRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/user/repository/UserRepository.java
@@ -1,7 +1,9 @@
 package com.efub.gogildong.user.repository;
 
+import com.efub.gogildong.schools.domain.School;
 import com.efub.gogildong.statistics.dto.DailyCountProjection;
 import com.efub.gogildong.user.domain.User;
+import com.efub.gogildong.user.domain.UserRole;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,6 +14,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    List<User> findBySchoolAndRole(School school, UserRole role);
     Optional<User> findByLoginId(String loginId);
     boolean existsByEmail(String email);
     boolean existsByLoginId(String loginId);


### PR DESCRIPTION
## 연관 이슈

#116 

<br/>

## 개요

관리자가 학교와 관련된 설정을 할 수 있는 api 기능 모음입니다.

<br/>

## 📌 구현 기능

- [x] 등록된 학교 리스트 조회 api
<img width="2048" height="1399" alt="image" src="https://github.com/user-attachments/assets/84db1d3f-06de-4423-b30f-ccab3d21ce03" />

- [x] 학교 검색 api
<img width="2048" height="1407" alt="image" src="https://github.com/user-attachments/assets/7633759d-10f2-4e5a-8628-05cfd986f298" />

- [x] 학교 추가 api
<img width="2048" height="1397" alt="image" src="https://github.com/user-attachments/assets/67ab155e-45b2-49b4-b9ee-1270b958f48a" />

<br/>

## ⚠️ 어려웠던 점과 해결 과정
막혔던 부분과 어떻게 해결했는지 작성해주세요. (아래 부분은 지우고 작성)
- 검색 로직 구현할 때 처음에 페이징 후 필터링을 적용해서 원하는 결과가 나오지 않았었음. 페이징 전에 필터링 조건을 모두 DB에 반영 → Page 객체에서 바로 결과 조회 가능하도록 로직 변경함.

<br/>
  
## ⚠️ 참고 사항 및 주의할 점
(아래 부분은 지우고 작성)
- 토큰 까서 role 이 관리자일 경우에만 설정 가능합니다.
- 기본 10개씩 페이징
