### PR TITLE
fix(#127): 제보 관리, 열람 요청에서 학교 관리자 권한을 강제하는 로직 추가

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/reports/controller/ReportController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/controller/ReportController.java
@@ -17,6 +17,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -100,6 +101,7 @@ public class ReportController {
     /*
     화장실 제보를 상세 조회합니다. (학교 관리자)
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/restroom/{restRoomReportId}")
     public ResponseEntity<RestRoomReportResponse> getRestRoomReport(@PathVariable("restRoomReportId") Long restRoomReportId,
                                                                     Authentication authentication) {
@@ -110,6 +112,7 @@ public class ReportController {
     /*
     제보 전체 목록을 조회합니다. (학교 관리자)
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping(" ")
     public ResponseEntity<ReportListResponse> getAllReport() {
         return ResponseEntity.ok(reportService.getAllReports());
@@ -118,6 +121,7 @@ public class ReportController {
     /*
     제보 공개 여부를 수정합니다. (학교 관리자)
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{reportId}")
     public ResponseEntity<ReportSummary> updateReportPublicStatus(@PathVariable Long reportId,
                                                                   @RequestBody @Valid UpdateReportPublicStatusRequest requestDto,
@@ -130,6 +134,7 @@ public class ReportController {
     /*
     제보 신고 내역을 조회합니다. (학교 관리자)
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/flags/{reportId}")
     public ResponseEntity<ReportFlagListResponse> getReportFlags(@PathVariable Long reportId,
                                                  Authentication authentication) {

--- a/gogildong/src/main/java/com/efub/gogildong/schools/controller/SchoolViewRequestController.java
+++ b/gogildong/src/main/java/com/efub/gogildong/schools/controller/SchoolViewRequestController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,6 +32,7 @@ public class SchoolViewRequestController {
     }
 
     // 학교 정보 열람 신청 상세 조회 (학교 관리자)
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/{requestId}")
     public ResponseEntity<SchoolViewRequestDetailResponse> getRequestDetail(Authentication authentication,
                                                                             @PathVariable final Long requestId) {
@@ -40,6 +42,7 @@ public class SchoolViewRequestController {
     }
 
     // 학교 정보 열람 신청 목록 조회 (학교 관리자)
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping
     public ResponseEntity<SchoolViewRequestListResponse> getAllRequests(Authentication authentication) {
         SchoolViewRequestListResponse response = schoolViewRequestService.getAllRequests();
@@ -47,6 +50,7 @@ public class SchoolViewRequestController {
     }
 
     // 학교 정보 열람 요청 상태 수정 (학교 관리자)
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{requestId}")
     public ResponseEntity<Void> updateRequestStatus(Authentication authentication,
                                                     @PathVariable final Long requestId,


### PR DESCRIPTION
## 연관 이슈

close #127 

<br/>

## 개요

제보 관리, 열람 요청에서 학교 관리자 권한을 강제하는 로직을 추가했습니다.

<br/>

## 📌 구현 기능

- [x] 제보 관리, 열람 요청에서 학교 관리자 권한을 강제하는 로직 추가

ADMIN이 아닌 다른 role이 접근했을 때 오류뜨는 거 확인했습니다.
  <img width="1612" height="932" alt="image" src="https://github.com/user-attachments/assets/f0c914ca-c206-466a-8755-1a73414e95f4" />

