### PR TITLE
feat(#126): 엘리베이터, 교실 제보 측정 기준 변경 및 제보 변수명 변경

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/facility/domain/Classroom.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/domain/Classroom.java
@@ -29,7 +29,7 @@ public class Classroom {
     private Float maxDoorWidth;
 
     @Column(nullable = false)
-    private Float doorHeight;
+    private Float doorHandleHeight;
 
     @Column(nullable = false)
     private Float minAisleWidth;
@@ -52,11 +52,11 @@ public class Classroom {
 
     @Builder
     public Classroom(Float doorWidth, Float minDoorWidth, Float maxDoorWidth,
-                    Float doorHeight, Float minAisleWidth, Boolean hasThreshold, DoorType doorType,  Facility facility) {
+                    Float doorHandleHeight, Float minAisleWidth, Boolean hasThreshold, DoorType doorType,  Facility facility) {
         this.doorWidth = doorWidth;
         this.minDoorWidth = minDoorWidth;
         this.maxDoorWidth = maxDoorWidth;
-        this.doorHeight = doorHeight;
+        this.doorHandleHeight = doorHandleHeight;
         this.minAisleWidth = minAisleWidth;
         this.hasThreshold = hasThreshold;
         this.doorType = doorType;
@@ -72,7 +72,7 @@ public class Classroom {
     // 제보 추가 시 교실 값 업데이트
     public void updateAggregate(ClassroomAggregateStat stat) {
         this.doorWidth = stat.getAvgDoorWidth();
-        this.doorHeight = stat.getAvgDoorHeight();
+        this.doorHandleHeight = stat.getAvgDoorHandleHeight();
         this.minAisleWidth = stat.getAvgMinAisleWidth();
         this.hasThreshold = stat.getAvgHasThreshold() >= 0.5;
         this.minDoorWidth = stat.getMinDoorWidth();

--- a/gogildong/src/main/java/com/efub/gogildong/facility/domain/Elevator.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/domain/Elevator.java
@@ -29,7 +29,7 @@ public class Elevator {
     private Float maxDoorWidth;
 
     @Column(nullable = false)
-    private Float doorHeight;
+    private Float interiorDepth;
 
     @Column(nullable = false)
     private Float maxControlPanelHeight;
@@ -43,11 +43,11 @@ public class Elevator {
 
     @Builder
     public Elevator(Float doorWidth, Float minDoorWidth, Float maxDoorWidth,
-                    Float doorHeight, Float maxControlPanelHeight, Facility facility) {
+                    Float interiorDepth, Float maxControlPanelHeight, Facility facility) {
         this.doorWidth = doorWidth;
         this.minDoorWidth = minDoorWidth;
         this.maxDoorWidth = maxDoorWidth;
-        this.doorHeight = doorHeight;
+        this.interiorDepth = interiorDepth;
         this.maxControlPanelHeight = maxControlPanelHeight;
         this.facility = facility;
     }
@@ -61,7 +61,7 @@ public class Elevator {
     // 제보 추가 시 엘리베이터 값 업데이트
     public void updateAggregate(ElevatorAggregateStat stat) {
         this.doorWidth = stat.getAvgDoorWidth();
-        this.doorHeight = stat.getAvgDoorHeight();
+        this.interiorDepth = stat.getAvgInteriorDepth();
         this.maxControlPanelHeight = stat.getAvgMaxControlPanelHeight();
         this.minDoorWidth = stat.getMinDoorWidth();
         this.maxDoorWidth = stat.getMaxDoorWidth();

--- a/gogildong/src/main/java/com/efub/gogildong/reports/domain/ClassroomReport.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/domain/ClassroomReport.java
@@ -24,7 +24,7 @@ public class ClassroomReport {
     private Float doorWidth;
 
     @Column(nullable = false)
-    private Float doorHeight;
+    private Float doorHandleHeight;
 
     @Column(nullable = false)
     private Float minAisleWidth;
@@ -35,8 +35,6 @@ public class ClassroomReport {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private DoorType doorType;
-
-    private String note;
 
     @OneToOne
     @Setter
@@ -49,15 +47,14 @@ public class ClassroomReport {
     private Classroom classroom;
 
     @Builder
-    public ClassroomReport(String classroomReportImage, Float doorWidth, Float doorHeight, Float minAisleWidth, Boolean hasThreshold,
-                           DoorType doorType, String note, Report report, Classroom classroom) {
+    public ClassroomReport(String classroomReportImage, Float doorWidth, Float doorHandleHeight, Float minAisleWidth, Boolean hasThreshold,
+                           DoorType doorType, Report report, Classroom classroom) {
         this.classroomReportImage = classroomReportImage;
         this.doorWidth = doorWidth;
-        this.doorHeight = doorHeight;
+        this.doorHandleHeight = doorHandleHeight;
         this.minAisleWidth = minAisleWidth;
         this.hasThreshold = hasThreshold;
         this.doorType = doorType;
-        this.note = note;
         this.report = report;
         this.classroom = classroom;
     }

--- a/gogildong/src/main/java/com/efub/gogildong/reports/domain/ElevatorReport.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/domain/ElevatorReport.java
@@ -23,12 +23,10 @@ public class ElevatorReport {
     private Float doorWidth;
 
     @Column(nullable = false)
-    private Float doorHeight;
+    private Float interiorDepth;
 
     @Column(nullable = false)
     private Float maxControlPanelHeight;
-
-    private String note;
 
     @OneToOne
     @Setter
@@ -41,12 +39,11 @@ public class ElevatorReport {
     private Elevator elevator;
 
     @Builder
-    public ElevatorReport(String elevatorReportImage, Float doorWidth, Float doorHeight, Float maxControlPanelHeight, String note, Report report, Elevator elevator) {
+    public ElevatorReport(String elevatorReportImage, Float doorWidth, Float  interiorDepth, Float maxControlPanelHeight, Report report, Elevator elevator) {
         this.elevatorReportImage = elevatorReportImage;
         this.doorWidth = doorWidth;
-        this.doorHeight = doorHeight;
+        this.interiorDepth =  interiorDepth;
         this.maxControlPanelHeight = maxControlPanelHeight;
-        this.note = note;
         this.report = report;
         this.elevator = elevator;
     }

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/classroom/NewClassroomReportRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/classroom/NewClassroomReportRequest.java
@@ -17,14 +17,14 @@ public class NewClassroomReportRequest {
     private Long floorId;
 
     @NotBlank(message = "시설 이름을 작성해주세요.")
-    private String facilityName;
+    private String facilityNickname;
 
     @NotBlank(message = "시설 사진을 포함해주세요!")
     private String classroomReportImage;
 
     private Float doorWidth;
 
-    private Float doorHeight;
+    private Float doorHandleHeight;
 
     private Float minAisleWidth;
 
@@ -32,12 +32,10 @@ public class NewClassroomReportRequest {
 
     private DoorType doorType;
 
-    private String note;
-
     public static Facility toFacilityEntity(NewClassroomReportRequest request, String facilityName, Floor floor) {
         return Facility.builder()
                 .facilityName(facilityName)
-                .facilityNickname(request.getFacilityName())
+                .facilityNickname(request.getFacilityNickname())
                 .facilityType(FacilityType.CLASSROOM)
                 .floor(floor)
                 .build();
@@ -47,17 +45,16 @@ public class NewClassroomReportRequest {
         return ClassroomReport.builder()
                 .classroomReportImage(request.getClassroomReportImage())
                 .doorWidth(request.getDoorWidth())
-                .doorHeight(request.getDoorHeight())
+                .doorHandleHeight(request.getDoorHandleHeight())
                 .minAisleWidth(request.getMinAisleWidth())
                 .hasThreshold(request.getHasThreshold())
                 .doorType(request.getDoorType())
-                .note(request.getNote())
                 .build();
     }
 
     public static Classroom toClassroomEntity(NewClassroomReportRequest request, Facility facility, ClassroomReport report) {
         Classroom classroom = Classroom.builder()
-                .doorHeight(request.getDoorHeight())
+                .doorHandleHeight(request.getDoorHandleHeight())
                 .doorWidth(request.getDoorWidth())
                 .minAisleWidth(request.getMinAisleWidth())
                 .hasThreshold(request.getHasThreshold())

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/elevator/NewElevatorReportRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/elevator/NewElevatorReportRequest.java
@@ -17,23 +17,21 @@ public class NewElevatorReportRequest {
     private Long floorId;
 
     @NotBlank(message = "시설 이름을 작성해주세요.")
-    private String facilityName;
+    private String facilityNickname;
 
     @NotBlank(message = "시설 사진을 포함해주세요!")
     private String elevatorReportImage;
 
     private Float doorWidth;
 
-    private Float doorHeight;
+    private Float interiorDepth;
 
     private Float maxControlPanelHeight;
-
-    private String note;
 
     public static Facility toFacilityEntity(NewElevatorReportRequest request, String facilityName, Floor floor) {
         return Facility.builder()
                 .facilityName(facilityName)
-                .facilityNickname(request.getFacilityName())
+                .facilityNickname(request.getFacilityNickname())
                 .facilityType(FacilityType.ELEVATOR)
                 .floor(floor)
                 .build();
@@ -43,15 +41,14 @@ public class NewElevatorReportRequest {
         return ElevatorReport.builder()
                 .elevatorReportImage(request.getElevatorReportImage())
                 .doorWidth(request.getDoorWidth())
-                .doorHeight(request.getDoorHeight())
+                .interiorDepth(request.getInteriorDepth())
                 .maxControlPanelHeight(request.getMaxControlPanelHeight())
-                .note(request.getNote())
                 .build();
     }
 
     public static Elevator toElevatorEntity(NewElevatorReportRequest request, Facility facility, ElevatorReport report) {
         Elevator elevator = Elevator.builder()
-                .doorHeight(request.getDoorHeight())
+                .interiorDepth(request.getInteriorDepth())
                 .doorWidth(request.getDoorWidth())
                 .maxControlPanelHeight(request.getMaxControlPanelHeight())
                 .facility(facility)

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/etc/NewEtcReportRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/etc/NewEtcReportRequest.java
@@ -17,7 +17,7 @@ public class NewEtcReportRequest {
     private Long floorId;
 
     @NotBlank(message = "시설 이름을 작성해주세요.")
-    private String facilityName;
+    private String facilityNickname;
 
     @NotBlank(message = "시설 사진을 포함해주세요!")
     private String etcReportImage;
@@ -28,7 +28,7 @@ public class NewEtcReportRequest {
     public static Facility toFacilityEntity(NewEtcReportRequest request, String facilityName, Floor floor) {
         return Facility.builder()
                 .facilityName(facilityName)
-                .facilityNickname(request.getFacilityName())
+                .facilityNickname(request.getFacilityNickname())
                 .facilityType(FacilityType.ETC)
                 .floor(floor)
                 .build();

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/restroom/NewRestRoomReportRequest.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/request/restroom/NewRestRoomReportRequest.java
@@ -18,7 +18,7 @@ public class NewRestRoomReportRequest {
     private Long floorId;
 
     @NotBlank(message = "시설 이름을 작성해주세요.")
-    private String facilityName;
+    private String facilityNickname;
 
     @NotBlank(message = "시설 사진을 포함해주세요!")
     private String restRoomReportImage;
@@ -44,7 +44,7 @@ public class NewRestRoomReportRequest {
     public static Facility toFacilityEntity(NewRestRoomReportRequest request, String facilityName, Floor floor) {
         return Facility.builder()
                 .facilityName(facilityName)
-                .facilityNickname(request.getFacilityName())
+                .facilityNickname(request.getFacilityNickname())
                 .facilityType(FacilityType.RESTROOM)
                 .floor(floor)
                 .build();

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/classroom/ClassroomAggregateStat.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/classroom/ClassroomAggregateStat.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 public class ClassroomAggregateStat {
 
     private Float avgDoorWidth;
-    private Float avgDoorHeight;
+    private Float avgDoorHandleHeight;
     private Float avgMinAisleWidth;
     private Float avgHasThreshold; // true 비율
     private Float minDoorWidth;

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/classroom/ClassroomReportResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/classroom/ClassroomReportResponse.java
@@ -15,11 +15,10 @@ public class ClassroomReportResponse {
     private UserResponseDto user;
     private String classroomReportImage;
     private Float doorWidth;
-    private Float doorHeight;
+    private Float doorHandleHeight;
     private Float minAisleWidth;
     private Boolean hasThreshold;
     private DoorType doorType;
-    private String note;
 
     public static ClassroomReportResponse from(ClassroomReport classroomReport) {
         return ClassroomReportResponse.builder()
@@ -28,11 +27,10 @@ public class ClassroomReportResponse {
                 .user(UserResponseDto.from(classroomReport.getReport().getUser()))
                 .classroomReportImage(classroomReport.getClassroomReportImage())
                 .doorWidth(classroomReport.getDoorWidth())
-                .doorHeight(classroomReport.getDoorHeight())
+                .doorHandleHeight(classroomReport.getDoorHandleHeight())
                 .minAisleWidth(classroomReport.getMinAisleWidth())
                 .hasThreshold(classroomReport.getHasThreshold())
                 .doorType(classroomReport.getDoorType())
-                .note(classroomReport.getNote())
                 .build();
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/elevator/ElevatorAggregateStat.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/elevator/ElevatorAggregateStat.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Builder
 public class ElevatorAggregateStat {
     private Float avgDoorWidth;
-    private Float avgDoorHeight;
+    private Float avgInteriorDepth;
     private Float avgMaxControlPanelHeight;
     private Float minDoorWidth;
     private Float maxDoorWidth;

--- a/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/elevator/ElevatorReportResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/dto/response/elevator/ElevatorReportResponse.java
@@ -13,9 +13,8 @@ public class ElevatorReportResponse {
     private UserResponseDto user;
     private String elevatorReportImage;
     private Float doorWidth;
-    private Float doorHeight;
+    private Float interiorDepth;
     private Float maxControlPanelHeight;
-    private String note;
 
     public static ElevatorReportResponse from(ElevatorReport elevatorReport) {
         return ElevatorReportResponse.builder()
@@ -24,9 +23,8 @@ public class ElevatorReportResponse {
                 .user(UserResponseDto.from(elevatorReport.getReport().getUser()))
                 .elevatorReportImage(elevatorReport.getElevatorReportImage())
                 .doorWidth(elevatorReport.getDoorWidth())
-                .doorHeight(elevatorReport.getDoorHeight())
+                .interiorDepth(elevatorReport.getInteriorDepth())
                 .maxControlPanelHeight(elevatorReport.getMaxControlPanelHeight())
-                .note(elevatorReport.getNote())
                 .build();
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/reports/service/ReportService.java
@@ -102,7 +102,7 @@ public class ReportService {
 
         user.addReport(report);
 
-        facility.updateNickname(request.getFacilityName());
+        facility.updateNickname(request.getFacilityNickname());
         restRoomReportRepository.save(restRoomReport);
         System.out.println("Dd");
         updateRestroomAggregate(facility.getRestroom());
@@ -189,7 +189,7 @@ public class ReportService {
 
         user.addReport(report);
 
-        facility.updateNickname(request.getFacilityName());
+        facility.updateNickname(request.getFacilityNickname());
 
         reportRepository.save(report);
         elevatorReportRepository.save(elevatorReport);
@@ -264,7 +264,7 @@ public class ReportService {
 
         user.addReport(report);
 
-        facility.updateNickname(request.getFacilityName());
+        facility.updateNickname(request.getFacilityNickname());
 
         reportRepository.save(report);
         classroomReportRepository.save(classroomReport);
@@ -406,14 +406,14 @@ public class ReportService {
 
         // 숫자 평균, min, max
         Float avgDoorWidth = (float) reports.stream().mapToDouble(ElevatorReport::getDoorWidth).average().orElse(elevator.getDoorWidth());
-        Float avgDoorHeight = (float) reports.stream().mapToDouble(ElevatorReport::getDoorHeight).average().orElse(elevator.getDoorHeight());
+        Float avgInteriorDepth = (float) reports.stream().mapToDouble(ElevatorReport::getInteriorDepth).average().orElse(elevator.getInteriorDepth());
         Float avgMaxControlPanelHeight = (float) reports.stream().mapToDouble(ElevatorReport::getMaxControlPanelHeight).average().orElse(elevator.getMaxControlPanelHeight());
         Float minDoorWidth = (float) reports.stream().mapToDouble(ElevatorReport::getDoorWidth).min().orElse(elevator.getMinDoorWidth());
         Float maxDoorWidth = (float) reports.stream().mapToDouble(ElevatorReport::getDoorWidth).max().orElse(elevator.getMaxDoorWidth());
 
         ElevatorAggregateStat stat = ElevatorAggregateStat.builder()
                 .avgDoorWidth(avgDoorWidth)
-                .avgDoorHeight(avgDoorHeight)
+                .avgInteriorDepth(avgInteriorDepth)
                 .avgMaxControlPanelHeight(avgMaxControlPanelHeight)
                 .minDoorWidth(minDoorWidth)
                 .maxDoorWidth(maxDoorWidth)
@@ -434,14 +434,14 @@ public class ReportService {
 
         // 숫자 평균, min, max
         Float avgDoorWidth = (float) reports.stream().mapToDouble(ClassroomReport::getDoorWidth).average().orElse(classroom.getDoorWidth());
-        Float avgDoorHeight = (float) reports.stream().mapToDouble(ClassroomReport::getDoorHeight).average().orElse(classroom.getDoorHeight());
+        Float avgDoorHandleHeight = (float) reports.stream().mapToDouble(ClassroomReport::getDoorHandleHeight).average().orElse(classroom.getDoorHandleHeight());
         Float avgMinAisleWidth = (float) reports.stream().mapToDouble(ClassroomReport::getMinAisleWidth).average().orElse(classroom.getMinAisleWidth());
         Float minDoorWidth = (float) reports.stream().mapToDouble(ClassroomReport::getDoorWidth).min().orElse(classroom.getMinDoorWidth());
         Float maxDoorWidth = (float) reports.stream().mapToDouble(ClassroomReport::getDoorWidth).max().orElse(classroom.getMaxDoorWidth());
 
         ClassroomAggregateStat stat = ClassroomAggregateStat.builder()
                 .avgDoorWidth(avgDoorWidth)
-                .avgDoorHeight(avgDoorHeight)
+                .avgDoorHandleHeight(avgDoorHandleHeight)
                 .avgMinAisleWidth(avgMinAisleWidth)
                 .avgHasThreshold(avgHasThreshold)
                 .minDoorWidth(minDoorWidth)

--- a/gogildong/src/main/java/com/efub/gogildong/statistics/repository/FacilityStatisticsRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/statistics/repository/FacilityStatisticsRepository.java
@@ -108,9 +108,6 @@ public class FacilityStatisticsRepository {
             QElevator elevator = QElevator.elevator;
             query.leftJoin(elevator).on(elevator.facility.eq(facility)).fetchJoin();
 
-            if (filter.getElevatorDoorHeightMin() != null) {
-                where.and(elevator.doorHeight.goe(filter.getElevatorDoorHeightMin()));
-            }
             if (filter.getElevatorDoorWidthMin() != null) {
                 where.and(elevator.doorWidth.goe(filter.getElevatorDoorWidthMin()));
             }
@@ -127,9 +124,6 @@ public class FacilityStatisticsRepository {
             QClassroom classroom = QClassroom.classroom;
             query.leftJoin(classroom).on(classroom.facility.eq(facility)).fetchJoin();
 
-            if (filter.getClassroomDoorHeightMin() != null) {
-                where.and(classroom.doorHeight.goe(filter.getClassroomDoorHeightMin()));
-            }
             if (filter.getClassroomDoorWidthMin() != null) {
                 where.and(classroom.doorWidth.goe(filter.getClassroomDoorWidthMin()));
             }
@@ -193,7 +187,6 @@ public class FacilityStatisticsRepository {
                         .doorWidth(e != null ? e.getDoorWidth() : null)
                         .minDoorWidth(e != null ? e.getMinDoorWidth() : null)
                         .maxDoorWidth(e != null ? e.getMaxDoorWidth() : null)
-                        .doorHeight(e != null ? e.getDoorHeight() : null)
                         .maxControlPanelHeight(e != null ? e.getMaxControlPanelHeight() : null)
 
                         .build();
@@ -213,7 +206,6 @@ public class FacilityStatisticsRepository {
                         .doorWidth(c != null ? c.getDoorWidth() : null)
                         .minDoorWidth(c != null ? c.getMinDoorWidth() : null)
                         .maxDoorWidth(c != null ? c.getMaxDoorWidth() : null)
-                        .doorHeight(c != null ? c.getDoorHeight() : null)
                         .minAisleWidth(c != null ? c.getMinAisleWidth() : null)
                         .hasThreshold(c != null ? c.getHasThreshold() : null)
                         .doorType(c != null ? c.getDoorType() : null)


### PR DESCRIPTION
## 연관 이슈

close #126 

<br/>

## 개요

엘리베이터: doorHeight(문 높이) -> interiorDepth(내부 깊이) 값 제보 받는 것으로 수정합니다.
교실: doorHeigh(문 높이) -> doorHandleHeight(손잡이 높이) 값 제보 받는 것으로 수정합니다.
각 시설 제보에서 facilityName -> facilityNickname으로 변수명을 수정합니다.
각 시설 제보에서 기타 시설 제외하고 note(추가설명) 필드를 제거합니다.

<br/>

## 📌 구현 기능

- [x] 엘리베이터 제보 측정 기준 변경 (문높이->내부 깊이)
- [x] 교실 제보 측정 기준 변경 (문높이->손잡이 높이)
- [x] 각 시설 제보에서 facilityName -> facilityNickname으로 변수명 수정


<br/>
  
## ⚠️ 참고 사항 및 주의할 점
수정 이후 화장실, 엘리베이터, 교실에 대한 기존/새로운 접근성 제보 postman 성공 확인했습니다.

FacilityStatisticsRepository.java 에서 기존 doorHeight에 대한 코드는 삭제하였습니다.


