### PR TITLE
feat: 시설 상세 조회 api 교실, 엘리베이터, 기타 분기 추가

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/ClassroomResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/ClassroomResponse.java
@@ -1,0 +1,24 @@
+package com.efub.gogildong.facility.dto.response;
+
+import com.efub.gogildong.facility.domain.Classroom;
+import com.efub.gogildong.facility.domain.DoorType;
+import com.efub.gogildong.facility.domain.Facility;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ClassroomResponse {
+    private FacilityDetailResponse facilityDetail;
+    private Boolean hasThreshold;
+    private DoorType doorType;
+
+    public static ClassroomResponse from(Classroom classroom) {
+        Facility facility = classroom.getFacility();
+        return ClassroomResponse.builder()
+                .facilityDetail(FacilityDetailResponse.from(facility))
+                .hasThreshold(classroom.getHasThreshold())
+                .doorType(classroom.getDoorType())
+                .build();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/ElevatorResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/ElevatorResponse.java
@@ -1,0 +1,24 @@
+package com.efub.gogildong.facility.dto.response;
+
+import com.efub.gogildong.facility.domain.Elevator;
+import com.efub.gogildong.facility.domain.Facility;
+import com.efub.gogildong.facility.domain.StaffApproved;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ElevatorResponse {
+    private FacilityDetailResponse facilityDetail;
+    private StaffApproved isStaffApproved;
+    private Boolean isAvailableDuringClass;
+
+    public static ElevatorResponse from(Elevator elevator) {
+        Facility facility = elevator.getFacility();
+        return ElevatorResponse.builder()
+                .facilityDetail(FacilityDetailResponse.from(facility))
+                .isStaffApproved(elevator.getIsStaffApproved())
+                .isAvailableDuringClass(elevator.getIsAvailableDuringClass())
+                .build();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/EtcResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/EtcResponse.java
@@ -1,0 +1,19 @@
+package com.efub.gogildong.facility.dto.response;
+
+import com.efub.gogildong.facility.domain.Etc;
+import com.efub.gogildong.facility.domain.Facility;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EtcResponse {
+    private FacilityDetailResponse facilityDetail;
+
+    public static EtcResponse from(Etc etc) {
+        Facility facility = etc.getFacility();
+        return EtcResponse.builder()
+                .facilityDetail(FacilityDetailResponse.from(facility))
+                .build();
+    }
+}

--- a/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/FacilityDetailResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/FacilityDetailResponse.java
@@ -14,7 +14,7 @@ public class FacilityDetailResponse {
     private String floorName;
     private Long facilityId;
     private String facilityName;
-    private String facilityNiceName;
+    private String facilityNickName;
     private String facilityType;
     private String reviewSummary;
     private LocalDateTime createdAt;
@@ -25,7 +25,7 @@ public class FacilityDetailResponse {
                 .floorName(facility.getFloor().getFloorName())
                 .facilityId(facility.getFacilityId())
                 .facilityName(facility.getFacilityName())
-                .facilityNiceName(facility.getFacilityNickname())
+                .facilityNickName(facility.getFacilityNickname())
                 .facilityType(facility.getFacilityType().name())
                 .reviewSummary(facility.getReviewSummary())
                 .createdAt(facility.getCreatedAt())

--- a/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityService.java
@@ -3,10 +3,7 @@ package com.efub.gogildong.facility.service;
 import com.efub.gogildong.facility.domain.Facility;
 import com.efub.gogildong.facility.domain.FacilityType;
 import com.efub.gogildong.facility.dto.request.FacilityImageFlagRequest;
-import com.efub.gogildong.facility.dto.response.FacilityDetailResponse;
-import com.efub.gogildong.facility.dto.response.FacilityImageListResponse;
-import com.efub.gogildong.facility.dto.response.FacilityImageSummaryResponse;
-import com.efub.gogildong.facility.dto.response.RestroomResponse;
+import com.efub.gogildong.facility.dto.response.*;
 import com.efub.gogildong.facility.respository.FacilityRepository;
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
@@ -53,7 +50,25 @@ public class FacilityService {
         // 각 타입별 Dto 변환 메서드 호출
         switch (facility.getFacilityType()) {
             case RESTROOM :
+                if (facility.getRestroom() == null) {
+                    return FacilityDetailResponse.from(facility);
+                }
                 return RestroomResponse.from(facility.getRestroom());
+            case CLASSROOM:
+                if (facility.getClassroom() == null) {
+                    return FacilityDetailResponse.from(facility);
+                }
+                return ClassroomResponse.from(facility.getClassroom());
+            case ELEVATOR:
+                if (facility.getElevator() == null) {
+                    return FacilityDetailResponse.from(facility);
+                }
+                    return ElevatorResponse.from(facility.getElevator());
+            case ETC:
+                if (facility.getEtc() == null) {
+                    return FacilityDetailResponse.from(facility);
+                }
+                return EtcResponse.from(facility.getEtc());
             default:
                 return FacilityDetailResponse.from(facility);
         }


### PR DESCRIPTION
## 연관 이슈

close #11 

<br/>

## 개요

시설 상세 조회 api 교실, 엘리베이터, 기타 분기 추가, 제보 없을 때 처리 추가

<br/>

## 📌 구현 기능

- [x] 시설 상세 조회 api 교실
<img width="2048" height="1396" alt="image" src="https://github.com/user-attachments/assets/d9060039-ad98-40be-875d-b5503c37d21f" />

- [x] 시설 상세 조회 api 엘리베이터
<img width="2048" height="1398" alt="image" src="https://github.com/user-attachments/assets/dc26873d-0298-4c32-9dcf-c9b363ec6d62" />

- [x] 시설 상세 조회 api 기타
<img width="1330" height="896" alt="image" src="https://github.com/user-attachments/assets/9c06a409-97a9-47fd-bd52-2cf5617a587f" />
