### PR TITLE
fix: 좋아요, 댓글 증감 추가, 사용자에 의해 이미 좋아요 생성 되었는지 응답 추가

### DIFF
--- a/gogildong/src/main/java/com/efub/gogildong/facility/domain/FacilityReview.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/domain/FacilityReview.java
@@ -67,4 +67,12 @@ public class FacilityReview extends BaseEntity {
     public void addFlag() {
         flagCount++;
     }
+
+    // 좋아요 수 증감
+    public void addLike() { likeCount++; }
+    public void deleteLike() { likeCount--; }
+
+    // 댓글 수 증감
+    public void addComment() { commentCount++; }
+    public void deleteComment() { commentCount--; }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/FacilityReviewCommentListResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/FacilityReviewCommentListResponse.java
@@ -10,13 +10,13 @@ import java.util.List;
 @Builder
 public class FacilityReviewCommentListResponse {
     private int total;
-    private FacilityReviewResponse review;
+    private FacilityReviewSummaryResponse review;
     private List<FacilityReviewCommentResponse> reviewComments;
 
-    public static FacilityReviewCommentListResponse from(FacilityReview review, List<FacilityReviewCommentResponse> comments) {
+    public static FacilityReviewCommentListResponse from(FacilityReview review, List<FacilityReviewCommentResponse> comments, boolean likedByUser) {
         return FacilityReviewCommentListResponse.builder()
                 .total(comments.size())
-                .review(FacilityReviewResponse.from(review))
+                .review(FacilityReviewSummaryResponse.from(review, likedByUser))
                 .reviewComments(comments)
                 .build();
     }

--- a/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/FacilityReviewSummaryResponse.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/dto/response/FacilityReviewSummaryResponse.java
@@ -14,16 +14,18 @@ public class FacilityReviewSummaryResponse {
     private String userName;
     private Long reviewId;
     private String reviewText;
+    private boolean likedByUser;
     private Integer likeCount;
     private Integer commentCount;
     private LocalDateTime createdAt;
 
-    public static FacilityReviewSummaryResponse from(FacilityReview review) {
+    public static FacilityReviewSummaryResponse from(FacilityReview review, boolean likedByUser) {
         return FacilityReviewSummaryResponse.builder()
                 .userId(review.getUser().getUserId())
                 .userName(review.getUser().getUsername())
                 .reviewId(review.getFacilityReviewId())
                 .reviewText(review.getReviewText())
+                .likedByUser(likedByUser)
                 .likeCount(review.getLikeCount())
                 .commentCount(review.getCommentCount())
                 .createdAt(review.getCreatedAt())

--- a/gogildong/src/main/java/com/efub/gogildong/facility/respository/FacilityReviewLikeRepository.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/respository/FacilityReviewLikeRepository.java
@@ -3,9 +3,12 @@ package com.efub.gogildong.facility.respository;
 import com.efub.gogildong.facility.domain.FacilityReview;
 import com.efub.gogildong.facility.domain.FacilityReviewLike;
 import com.efub.gogildong.user.domain.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +16,15 @@ public interface FacilityReviewLikeRepository extends JpaRepository<FacilityRevi
     boolean existsByFacilityReviewAndUser(FacilityReview review, User user);
 
     Optional<FacilityReviewLike> findByFacilityReviewAndUser(FacilityReview facilityReview, User user);
+
+    @Query("""
+    select frl.facilityReview.facilityReviewId
+    from FacilityReviewLike frl
+    where frl.user = :user
+      and frl.facilityReview in :reviews
+""")
+    List<Long> findLikedReviewIdsByUserAndReviews(
+            @Param("user") User user,
+            @Param("reviews") List<FacilityReview> reviews
+    );
 }

--- a/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewCommentService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewCommentService.java
@@ -9,6 +9,7 @@ import com.efub.gogildong.facility.dto.response.FacilityReviewCommentListRespons
 import com.efub.gogildong.facility.dto.response.FacilityReviewCommentResponse;
 import com.efub.gogildong.facility.respository.FacilityReviewCommentFlagRepository;
 import com.efub.gogildong.facility.respository.FacilityReviewCommentRepository;
+import com.efub.gogildong.facility.respository.FacilityReviewLikeRepository;
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
 import com.efub.gogildong.global.util.EntityFinder;
@@ -33,6 +34,7 @@ public class FacilityReviewCommentService {
     private final EntityFinder entityFinder;
     private final SchoolViewRequestService schoolViewRequestService;
     private final PointService pointService;
+    private final FacilityReviewLikeRepository facilityReviewLikeRepository;
 
     private static final int REVIEW_COMMENT_POINTS = 5;
     private final CoinService coinService;
@@ -50,11 +52,14 @@ public class FacilityReviewCommentService {
         List<FacilityReviewComment> commentList =
                 facilityReviewCommentRepository.findAllByFacilityReview_FacilityReviewId(facilityReviewId);
 
+        boolean likedByUser =
+                facilityReviewLikeRepository.existsByFacilityReviewAndUser(review, user);
+
         List<FacilityReviewCommentResponse> comments = commentList.stream()
                 .map(FacilityReviewCommentResponse::from)
                 .toList();
 
-        return FacilityReviewCommentListResponse.from(review, comments);
+        return FacilityReviewCommentListResponse.from(review, comments,  likedByUser);
     }
 
     // 시설 리뷰 댓글 작성
@@ -66,6 +71,8 @@ public class FacilityReviewCommentService {
 
         // 시설 리뷰 댓글 작성 권한 검사
         schoolViewRequestService.validateViewRequestBySchoolAndUser(school, user);
+
+        review.addComment();
 
         FacilityReviewComment comment = request.toEntity(review, user);
         facilityReviewCommentRepository.save(comment);
@@ -111,6 +118,7 @@ public class FacilityReviewCommentService {
         // 작성자 검사
         validateCommentAuthor(comment, user);
 
+        review.deleteComment();
         facilityReviewCommentRepository.deleteById(commentId);
     }
 

--- a/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewLikeService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewLikeService.java
@@ -37,6 +37,9 @@ public class FacilityReviewLikeService {
             throw new GoGildongException(ExceptionCode.FACILITY_REVIEW_LIKE_ALREADY_EXISTS);
         }
 
+        // 리뷰 상태 변결
+        review.addLike();
+        // 좋아요 엔티티 생성
         FacilityReviewLike like = FacilityReviewLike.builder()
                 .facilityReview(review)
                 .user(user)
@@ -59,11 +62,9 @@ public class FacilityReviewLikeService {
         FacilityReviewLike reviewLike = facilityReviewLikeRepository.findByFacilityReviewAndUser(review, user)
                 .orElseThrow(() -> new GoGildongException(ExceptionCode.FACILITY_REVIEW_LIKE_NOT_FOUND));
 
-        // 좋아요 생성자 검사
-        if(!reviewLike.getUser().getUserId().equals(user.getUserId())) {
-            throw new GoGildongException(ExceptionCode.UNAUTHORIZED_ACCESS);
-        }
-
+        // 리뷰 상태 변경
+        review.deleteLike();
+        // 좋아요 엔티티 삭제
         facilityReviewLikeRepository.delete(reviewLike);
     }
 }

--- a/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewService.java
+++ b/gogildong/src/main/java/com/efub/gogildong/facility/service/FacilityReviewService.java
@@ -8,6 +8,7 @@ import com.efub.gogildong.facility.dto.response.FacilityReviewListResponse;
 import com.efub.gogildong.facility.dto.response.FacilityReviewResponse;
 import com.efub.gogildong.facility.dto.response.FacilityReviewSummaryResponse;
 import com.efub.gogildong.facility.respository.FacilityReviewFlagRepository;
+import com.efub.gogildong.facility.respository.FacilityReviewLikeRepository;
 import com.efub.gogildong.facility.respository.FacilityReviewRepository;
 import com.efub.gogildong.global.exception.ExceptionCode;
 import com.efub.gogildong.global.exception.GoGildongException;
@@ -35,6 +36,7 @@ public class FacilityReviewService {
     private final FacilityReviewRepository facilityReviewRepository;
     private final SchoolViewRequestService schoolViewRequestService;
     private final PointService pointService;
+    private final FacilityReviewLikeRepository facilityReviewLikeRepository;
 
     private static final int REVIEW_POINTS = 5;
     private final CoinService coinService;
@@ -53,8 +55,17 @@ public class FacilityReviewService {
         PageRequest pageRequest = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<FacilityReview> reviewPage = facilityReviewRepository.findByFacility(facility, pageRequest);
 
-        List<FacilityReviewSummaryResponse> reviewList = reviewPage.getContent().stream()
-                .map(FacilityReviewSummaryResponse::from)
+        List<FacilityReview> reviews = reviewPage.getContent();
+
+        // 유저가 좋아요 누른 리뷰 ID 목록
+        List<Long> likedReviewIds =
+                facilityReviewLikeRepository.findLikedReviewIdsByUserAndReviews(user, reviews);
+
+        List<FacilityReviewSummaryResponse> reviewList = reviews.stream()
+                .map(review -> FacilityReviewSummaryResponse.from(
+                        review,
+                        likedReviewIds.contains(review.getFacilityReviewId())
+                ))
                 .toList();
 
         return FacilityReviewListResponse.from(reviewPage, facility, reviewList);


### PR DESCRIPTION
## 연관 이슈

close #11 

<br/>

## 개요

좋아요, 댓글 증감 추가, 사용자에 의해 이미 좋아요 생성 되었는지 응답 추가

<br/>

## 📌 구현 기능

- [x] 시설 리뷰 조회, 시설 리뷰 댓글 조회 시 리뷰에 대해 likedByUser 응답 추가
- [x] 좋아요, 댓글 증감 활성화
<img width="1329" height="923" alt="image" src="https://github.com/user-attachments/assets/e8b47592-8b39-47d8-bec4-82145062635b" />
<img width="1326" height="936" alt="image" src="https://github.com/user-attachments/assets/f51f4888-0035-4379-8edd-98db0d4cb4d0" />
